### PR TITLE
Fix translation installation

### DIFF
--- a/.claude/skills/joomla-translations/SKILL.md
+++ b/.claude/skills/joomla-translations/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: joomla-translations
+description: >
+  Use this skill whenever creating, editing, or reviewing any user-facing
+  string in a Joomla 6 extension (component, module, plugin, template): admin
+  field labels and descriptions, form/XML labels, toolbar buttons, error and
+  success messages, tooltips, JS-exposed strings (Text::script), email
+  templates. Triggers on any edit to a language .ini file, any new or changed
+  Text::_() / Text::sprintf() / Text::plural() call, any <field> label/
+  description/hint in XML manifests or forms, or any request to add/update a
+  translation. Always update en-GB, fr-FR, and de-DE together, keep wording
+  aligned across the three, and apply correct French typography (fine
+  non-breaking spaces, French quotation marks, capitalization rules).
+---
+
+# Traductions Joomla 6 (en-GB / fr-FR / de-DE)
+
+## Quand s'applique cette skill
+Dès qu'une chaîne destinée à l'utilisateur est créée ou modifiée :
+libellés de champs, descriptions, infobulles, messages d'erreur/succès,
+boutons de la toolbar admin, libellés XML (`<field label="..." description="...">`),
+chaînes exposées au JS via `Text::script()`.
+
+## Règle d'or
+**Une clé de langue ne doit jamais être ajoutée ou modifiée dans une seule
+langue.** Les trois fichiers `en-GB`, `fr-FR`, `de-DE` sont édités dans le
+même tour de modification, avec un sens strictement équivalent.
+
+## 1. Emplacement des fichiers
+
+```
+admin/language/en-GB/en-GB.com_xxx.ini
+admin/language/en-GB/en-GB.com_xxx.sys.ini   (nom, description du manifeste)
+admin/language/fr-FR/fr-FR.com_xxx.ini
+admin/language/fr-FR/fr-FR.com_xxx.sys.ini
+admin/language/de-DE/de-DE.com_xxx.ini
+admin/language/de-DE/de-DE.com_xxx.sys.ini
+
+site/language/en-GB/en-GB.com_xxx.ini   (chaînes front-end, si différentes)
+site/language/fr-FR/fr-FR.com_xxx.ini
+site/language/de-DE/de-DE.com_xxx.ini
+```
+
+- `*.sys.ini` : uniquement le nom et la description visibles dans le
+  gestionnaire d'extensions (chargé même quand l'extension est désactivée).
+- `*.ini` (sans `.sys`) : toutes les autres chaînes, chargées à l'exécution.
+
+## 2. Convention de nommage des clés
+
+Format : `COM_<EXTENSION>_<CONTEXTE>_<ELEMENT>`, toujours en MAJUSCULES,
+underscores, pas d'espaces ni d'accents dans la clé elle-même.
+
+```ini
+COM_CONTENTBUILDERNG_FIELD_API_KEY_LABEL="API Key"
+COM_CONTENTBUILDERNG_FIELD_API_KEY_DESC="Your Anthropic API key, used for completions."
+COM_CONTENTBUILDERNG_ERROR_INVALID_KEY="The provided API key is invalid."
+COM_CONTENTBUILDERNG_TOOLBAR_REINDEX="Reindex"
+COM_CONTENTBUILDERNG_N_ITEMS_INDEXED_1="%d item indexed"
+COM_CONTENTBUILDERNG_N_ITEMS_INDEXED_MORE="%d items indexed"
+```
+
+Suffixes courants à respecter pour la cohérence avec le cœur Joomla :
+- `_LABEL` pour le libellé d'un champ
+- `_DESC` pour la description/infobulle d'un champ
+- `_HINT` pour le placeholder
+- `_N_ITEMS_..._1` / `_..._MORE` pour le pluriel (cf. `Text::plural()`)
+
+## 3. Alignement du sens entre les langues
+
+Pour chaque clé, les trois traductions doivent :
+- exprimer **exactement** la même information (pas de paraphrase libre ni
+  d'ajout/suppression de nuance) ;
+- avoir un registre cohérent (vouvoiement en français, formel en allemand —
+  `Sie`, jamais `du`, dans une interface d'administration) ;
+- conserver les mêmes espaces réservés (`%s`, `%d`, `%1$s`...) **dans le même
+  ordre logique** — utiliser les index positionnels (`%1$s`, `%2$d`) dès que
+  l'ordre des arguments diffère entre langues, ce qui est fréquent en
+  allemand (ordre des mots différent).
+
+Exemple correct (ordre des arguments figé par index, pas par position) :
+
+```ini
+; en-GB
+COM_CONTENTBUILDERNG_MSG_REINDEXED="%1$s items reindexed in %2$s seconds"
+; fr-FR
+COM_CONTENTBUILDERNG_MSG_REINDEXED="%1$s éléments réindexés en %2$s secondes"
+; de-DE
+COM_CONTENTBUILDERNG_MSG_REINDEXED="%1$s Elemente in %2$s Sekunden neu indiziert"
+```
+
+## 4. Typographie française (fr-FR)
+
+À appliquer systématiquement dans les fichiers `fr-FR` :
+
+- **Espace fine insécable** avant `:`, `?`, `!`, `;` lorsque le rendu final
+  est du HTML/texte affiché à l'utilisateur (utiliser `&#8239;` ou une espace
+  insécable normale `&nbsp;` selon ce que le moteur de template restitue
+  correctement — à défaut de certitude sur le rendu, préférer une espace
+  insécable simple plutôt que rien).
+- **Guillemets français** « comme ceci » avec espace insécable interne,
+  jamais de guillemets droits `"..."` dans le texte affiché (les guillemets
+  droits restent les délimiteurs INI, ce n'est pas le sujet ici).
+- **Majuscules** : seule la première lettre d'un libellé de champ est
+  capitalisée (« Clé API », pas « Clé API » → correct ; éviter
+  « Clé Api » ou « CLÉ API » sauf si l'anglais lui-même est tout en
+  capitales pour un acronyme volontaire).
+- **Accents obligatoires**, y compris sur les majuscules (« Écrire »,
+  pas « Ecrire »).
+- Pas d'anglicisme évitable (« télécharger » plutôt que « uploader » quand
+  un équivalent existe nativement dans Joomla FR).
+
+## 5. Workflow de modification
+
+1. Identifier ou créer la clé dans `en-GB` (source de vérité sémantique).
+2. Ajouter immédiatement la même clé dans `fr-FR` et `de-DE`, dans le
+   fichier correspondant (`.ini` ou `.sys.ini` selon le contexte, cf. §1).
+3. Vérifier que les trois fichiers gardent le même **ordre de clés** (facilite
+   la relecture en diff).
+4. Si la chaîne est utilisée en JS, vérifier qu'elle est bien déclarée via
+   `Text::script('COM_XXX_KEY')` côté PHP avant d'être consommée par
+   `Joomla.Text._('COM_XXX_KEY')` côté JS — sinon elle n'existera que côté
+   serveur.
+5. Ne jamais laisser une clé `TODO`/non traduite : si la traduction définitive
+   n'est pas connue, le signaler explicitement au lieu de dupliquer le texte
+   anglais comme valeur fr-FR/de-DE.
+
+## 6. Ce que cette skill ne couvre pas
+- La création de nouvelles langues au-delà de en-GB/fr-FR/de-DE (hors
+  périmètre, cf. `AGENTS.md`/`CLAUDE.md`).
+- La logique de fallback de langue Joomla (gérée nativement par le cœur,
+  pas de workaround à coder).

--- a/README.md
+++ b/README.md
@@ -1,40 +1,29 @@
-<!-- ABOUT THE PROJECT -->
-## About the Project
+# ContentBuilder NG
 
-This repository provides **community-maintained updates and fixes for ContentBuilder**, 
-a Joomla extension originally developed by **Crosstec**. The original Crosstec project 
-is no longer maintained or supported.
+Community-maintained **Joomla 6 rewrite** of ContentBuilder, originally developed by Crosstec. The original project is no longer maintained.
 
-This ContentBuilerng (new gen) has been highly refactored for Joomla 6 native support. 
-New Gen releases releases will be named: "com_contentBuilerng-6.1.xx.zip" and above.
+ContentBuilder NG has been fully refactored for native Joomla 6 support: deprecated APIs removed, MVC restructured, user interface modernised, and new features added (Preview mode, drag-and-drop reordering, API endpoint, …).
 
-This initiative aims to keep the extension usable on modern Joomla installations by:
-- fixing compatibility issues
-- removing deprecated APIs
-- adapting the codebase to 6.x
-- adding Preview mode
-- improving user interface behaviors, ...
-
-⚠️ **This is NOT an official Crosstec project.**  
-All trademarks and original copyrights remain the property of their respective owners.
+> ⚠️ **This is NOT an official Crosstec project.**  
+> All trademarks and original copyrights remain the property of their respective owners.
 
 ---
 
 ## Compatibility
 
-- ✅ Joomla 5.4.x (not tested, should be OK **without** the Backward Compatibility plugin)
-- ✅ Joomla 6.x. (tested **with and witout** the Backward Compatibility plugin)
-- ✅ PHP 8.3 
-
-⚠️ **This is NOT an official ContentBuilder repository.**  
-This project is maintained by volunteers and provided *as-is*.
+| | |
+|---|---|
+| Joomla | 6.x — tested with and without the Backward Compatibility plugin |
+| PHP | 8.1 or later |
 
 ---
 
 ## Project Status
 
-🚧 This project is developed on a **best-effort basis**.  
+🚧 Developed on a **best-effort basis**.  
 Only **GitHub Releases** should be considered stable and suitable for production use.
+
+---
 
 ## Documentation
 
@@ -47,104 +36,26 @@ Only **GitHub Releases** should be considered stable and suitable for production
 
 ## Migration Notes
 
-The component installer performs the supported database, extension, plugin and menu
-migrations automatically. Do not uninstall the legacy component before installing the
-ContentBuilder NG package.
+The component installer performs all supported database, extension, plugin and menu migrations automatically. Do not uninstall the legacy component before installing the ContentBuilder NG package.
 
-For the complete operational procedure, including backups, validation, DB Repair,
-rollback and known pitfalls, see the
-**[Administrator Migration Guide](MIGRATION_GUIDE.md)**.
+For the complete operational procedure — backups, validation, DB Repair, rollback and known pitfalls — see the **[Administrator Migration Guide](MIGRATION_GUIDE.md)**.
 
-Manual SQL is not required during a normal migration. It is reserved for diagnosed
-table collisions or recovery after a failed migration.
-
-Test execution, measured coverage, package validation and the Joomla installation
-smoke test are documented in the **[Testing Guide](TESTING.md)**.
-
-### AJAX Endpoint Migration
-
-The old component-specific AJAX stack has been removed.
-
-Removed:
-- `task=ajax.display`
-
-Replacement:
-- use the component API endpoint with JSON responses
-- endpoint format:
-  - `index.php?option=com_contentbuilderng&task=api.display&format=json&action=...`
-
-Current migrated actions:
-- `action=rating`
-- `action=get-unique-values`
-- `action=stats`
-
-URL migration example:
-
-Old:
-
-```text
-index.php?option=com_contentbuilder&task=ajax.display&id=25&subject=rating&record_id=16
-```
-
-New:
-
-```text
-index.php?option=com_contentbuilderng&task=api.display&format=json&action=rating&id=25&record_id=16
-```
-
-Form statistics:
-
-```text
-index.php?option=com_contentbuilderng&task=api.display&format=json&action=stats&id=25
-```
-
-Requires the `Stats` permission for the selected view.
-
-Response format:
-
-```json
-{
-  "success": true,
-  "messages": [],
-  "data": {}
-}
-```
-
-Sparse fieldsets are supported on `GET` requests:
-
-```text
-index.php?option=com_contentbuilderng&task=api.display&id=25&fields[items]=record_id,title,slug
-index.php?option=com_contentbuilderng&task=api.display&id=25&action=stats&fields[records]=total,published
-```
-
-`fields[items]` accepts both item properties such as `record_id` and allowed business field names stored in `values`.
-When sparse fieldsets are used, top-level resources not named in `fields[...]` are omitted. Request several resources with several parameters, for example `fields[records]=total&fields[ratings]=average`.
-
-There is no backward compatibility for `task=ajax.display`.
+Manual SQL is not required during a normal migration. It is reserved for diagnosed table collisions or recovery after a failed migration.
 
 ---
 
 ## Download
 
-For stable versions:
-1. Go to the **Tags** or **Releases** section
+1. Go to the **Releases** section
 2. Select the latest version
-3. Download the packaged release asset named `com_contentbuilderng-<version>.zip`
+3. Download the release asset named `com_contentbuilderng-<version>.zip`
 4. Install via the Joomla Extension Manager
 
-The automatically generated GitHub **Source code (zip)** archive is a development
-source snapshot, not the assembled Joomla installation package.
+> The automatically generated GitHub **Source code (zip)** archive is a development snapshot, not an installable Joomla package.
 
 ---
 
 ## Disclaimer
 
-This software is provided **"as is"**, without warranty of any kind, express or implied.
-
-The maintainers provide this code on a **best-effort basis** and make no guarantees
-regarding correctness, stability, security, or fitness for any particular purpose.
-
-In no event shall the maintainers be held liable for any damages, data loss, or other
-issues arising from the use of this software.
-
-Use this code **at your own risk**.
+This software is provided **"as is"**, without warranty of any kind.  
+The maintainers make no guarantees regarding correctness, stability, security, or fitness for any particular purpose, and accept no liability for damages or data loss arising from its use.

--- a/admin/src/Controller/FormController.php
+++ b/admin/src/Controller/FormController.php
@@ -210,7 +210,7 @@ class FormController extends BaseFormController
     // Elles doivent utiliser Elements
     public function listorderup(): void
     {
-        $formId = (int) $this->input->getInt('id');
+        $formId = $this->resolveFormId();
         if (!$this->persistInlineElementSettings($formId)) {
             return;
         }
@@ -222,7 +222,7 @@ class FormController extends BaseFormController
 
     public function listorderdown(): void
     {
-        $formId = (int) $this->input->getInt('id');
+        $formId = $this->resolveFormId();
         if (!$this->persistInlineElementSettings($formId)) {
             return;
         }
@@ -236,7 +236,7 @@ class FormController extends BaseFormController
     {
         $this->checkToken();
 
-        $formId = (int) $this->input->getInt('id');
+        $formId = $this->resolveFormId();
         $orderMap = (array) $this->input->post->get('order', [], 'array');
 
         if (empty($orderMap)) {
@@ -937,6 +937,18 @@ class FormController extends BaseFormController
         $db->setQuery($query);
 
         return array_map('intval', (array) $db->loadColumn());
+    }
+
+    private function resolveFormId(): int
+    {
+        $formId = (int) $this->input->getInt('id');
+
+        if ($formId <= 0) {
+            $jform = (array) $this->input->post->get('jform', [], 'array');
+            $formId = (int) ($jform['id'] ?? 0);
+        }
+
+        return $formId;
     }
 
     private function getEditRedirectUrl(int $formId): string

--- a/admin/src/Service/InstallerService.php
+++ b/admin/src/Service/InstallerService.php
@@ -149,6 +149,23 @@ final class InstallerService
                 $this->log("[WARNING] Failed removing obsolete file {$path}: " . $e->getMessage(), Log::WARNING);
             }
         }
+
+        // Remove the legacy `languages/` (plural) folder — an old naming convention that shadows
+        // the current `language/` (singular) folder. Done in postflight so the new language/
+        // folder is already in place before the old one is deleted.
+        $staleDir = JPATH_ADMINISTRATOR . '/components/com_contentbuilderng/languages';
+
+        if (is_dir($staleDir)) {
+            try {
+                if (Folder::delete($staleDir)) {
+                    $this->log('[OK] Removed stale component language directory (languages/ → language/).');
+                } else {
+                    $this->log('[WARNING] Could not remove stale component language directory: ' . $staleDir, Log::WARNING);
+                }
+            } catch (\Throwable $e) {
+                $this->log('[WARNING] Error removing stale component language directory: ' . $e->getMessage(), Log::WARNING);
+            }
+        }
     }
 
     /**
@@ -199,6 +216,7 @@ final class InstallerService
         } else {
             $this->log("[OK] Purged {$totalRemoved} stale ContentBuilder language file(s) before installation.");
         }
+
     }
 
     public function removeObsoleteLanguageFiles(): void

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -1,12 +1,12 @@
 <extension type="component" method="upgrade" version="6.0">
     <name>COM_CONTENTBUILDERNG</name>
-    <creationDate>2026-06-24</creationDate>
+    <creationDate>2026-06-29</creationDate>
     <author>XDA+GIL</author>
     <authorEmail>bf@vcmb.fr</authorEmail>
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>Licensed under the GNU General Public License, version 2 or (at your option) any later version (SPDX: GPL-2.0-or-later).</license>
-    <version>6.1.7-RC55</version>
+    <version>6.1.7-RC56</version>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>
 
     <!-- ===================== -->

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,10 +6,10 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.7-RC55</version>
+		<version>6.1.7-RC56</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC55/com_contentbuilderng-6.1.7-RC55.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC56/com_contentbuilderng-6.1.7-RC56.zip</downloadurl>
 		<sha256>9eb41e63a5e8b4242f7595e994be32d49ac1d28640a0bcc35fa515c6cf115e6d</sha256>
 		</downloads>
 		<tags>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,7 +10,7 @@ The project is a community modernization of the former Crosstec ContentBuilder
 extension. It is independent from the historical product and is provided without
 warranty.
 
-> ℹ️ **Note:** this documentation describes component version `6.1.7-RC55` (the
+> ℹ️ **Note:** this documentation describes component version `6.1.7-RC56` (the
 > `<version>` field in `com_contentbuilderng.xml`). Screens and options may change
 > between versions.
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -10,7 +10,7 @@ Le projet est issu de la migration et de la modernisation de l'ancien ContentBui
 de Crosstec. Il s'agit d'un projet communautaire, distinct du produit historique et
 fourni sans garantie.
 
-> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC55` du composant
+> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC56` du composant
 > (champ `<version>` du fichier `com_contentbuilderng.xml`). Les écrans et options
 > peuvent évoluer d'une version à l'autre.
 

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Download</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Image Scale</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG Permission Observer</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Rating</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
+++ b/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
     <name>ContentBuilder NG - Content - Stats</name>
-    <creationDate>2026-06-24</creationDate>
+    <creationDate>2026-06-29</creationDate>
     <author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.7-RC55</version>
+    <version>6.1.7-RC56</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_STATS_XML_DESCRIPTION</description>
     <files>
         <filename plugin="contentbuilderng_stats">contentbuilderng_stats.php</filename>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_listaction" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - List Action - Trash</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_listaction" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - List Action - Untrash</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_submit" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Submit - Sample</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Blank</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-06-24</creationDate>
+  <creationDate>2026-06-29</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC55</version>
+  <version>6.1.7-RC56</version>
   <description><![CDATA[A blank theme without any style]]></description>
   <files>
     <filename plugin="blank">blank.php</filename>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Dark</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-06-24</creationDate>
+  <creationDate>2026-06-29</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC55</version>
+  <version>6.1.7-RC56</version>
   <description><![CDATA[A dark mode theme based on Joomla 6]]></description>
 
   <files>

--- a/plugins/contentbuilderng_themes/joomla6/joomla6.xml
+++ b/plugins/contentbuilderng_themes/joomla6/joomla6.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Joomla 6</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-06-24</creationDate>
+  <creationDate>2026-06-29</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC55</version>
+  <version>6.1.7-RC56</version>
   <description><![CDATA[A Joomla 6 compatible theme]]></description>
 
   <files>

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Khepri</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-06-24</creationDate>
+  <creationDate>2026-06-29</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC55</version>
+  <version>6.1.7-RC56</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
   <files>
     <filename plugin="khepri">khepri.php</filename>

--- a/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
+++ b/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Date is Valid</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
+++ b/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Date Not Before</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/email/email.xml
+++ b/plugins/contentbuilderng_validation/email/email.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Email</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/equal/equal.xml
+++ b/plugins/contentbuilderng_validation/equal/equal.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Equal</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/notempty/notempty.xml
+++ b/plugins/contentbuilderng_validation/notempty/notempty.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Not Empty</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_verify" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify - Pass-Through</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_verify" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify - PayPal</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="6.0" method="upgrade">
 	<name>ContentBuilder NG System</name>
-	<creationDate>2026-06-24</creationDate>
+	<creationDate>2026-06-29</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC55</version>
+	<version>6.1.7-RC56</version>
 
 	<description>
 	<![CDATA[


### PR DESCRIPTION
## Résumé

- **Fix traductions** : ajout du nettoyage du dossier `languages/` (pluriel, ancienne convention) dans `removeObsoleteFiles()` — exécuté en postflight une fois les nouveaux fichiers `language/` en place.
- **Fix drag-and-drop reorder** : `FormController::saveorder()`, `listorderup()` et `listorderdown()` lisaient `id` depuis l'URL, absente car le formulaire poste sur `action="index.php"`. Ajout de `resolveFormId()` qui se rabat sur `jform[id]` — le redirect renvoyait systématiquement vers `id=0` (formulaire vierge) au lieu du formulaire courant.

## Test plan

- [ ] Installer le composant par-dessus une ancienne version ayant un dossier `languages/` (pluriel) : vérifier en postflight que le dossier est supprimé et que les traductions fonctionnent.
- [ ] Ouvrir un formulaire en édition, glisser-déposer une ligne pour réordonner : vérifier que le redirect revient bien sur le même formulaire et que le nouvel ordre est persisté.
- [ ] Vérifier que les boutons ↑ / ↓ (`listorderup` / `listorderdown`) redirigent également sur le bon formulaire.
- [ ] Vérifier que le drag-and-drop dans les vues `storages` et `forms` (liste) n'est pas affecté.