### PR TITLE
Fix About template imports

### DIFF
--- a/admin/tmpl/about/audit_report.php
+++ b/admin/tmpl/about/audit_report.php
@@ -1,4 +1,10 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+?>
 
 <div class="card mt-3" id="cb-audit-section">
     <div class="card-body">

--- a/admin/tmpl/about/installed_plugins.php
+++ b/admin/tmpl/about/installed_plugins.php
@@ -1,4 +1,9 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+?>
 
 <div class="card mt-3">
     <div class="card-body p-0">

--- a/admin/tmpl/about/js_libraries.php
+++ b/admin/tmpl/about/js_libraries.php
@@ -1,4 +1,9 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+?>
 
 <div class="card mt-3">
     <div class="card-body p-0">

--- a/admin/tmpl/about/log.php
+++ b/admin/tmpl/about/log.php
@@ -1,4 +1,9 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+?>
 
 <div class="card mt-3">
     <div class="card-body">

--- a/admin/tmpl/about/php_libraries.php
+++ b/admin/tmpl/about/php_libraries.php
@@ -1,4 +1,9 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+?>
 
 <div class="card mt-3">
     <div class="card-body p-0">

--- a/admin/tmpl/about/repair_workflow.php
+++ b/admin/tmpl/about/repair_workflow.php
@@ -1,4 +1,9 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+?>
 
 <?php if ($repairWorkflowIsActive) : ?>
     <div class="card mt-3">

--- a/admin/tmpl/about/version_summary.php
+++ b/admin/tmpl/about/version_summary.php
@@ -1,4 +1,9 @@
-<?php \defined('_JEXEC') or die; ?>
+<?php
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Language\Text;
+?>
 
 <div class="card mt-3 cb-about-version-card">
     <div class="card-body p-3 p-lg-4">


### PR DESCRIPTION
## Résumé

- Corrige l’erreur fatale `Class "Text" not found` sur l’écran admin `About`.
- Ajoute les imports Joomla manquants dans les sous-templates About extraits.
- Ajoute aussi `Route` dans `audit_report.php`, qui génère des liens admin.

## Contexte

La PR #41 a découpé `admin/tmpl/about/default.php` en plusieurs sous-templates inclus via `require`.

En PHP, les imports `use` du fichier parent ne sont pas hérités par les fichiers inclus. Les sous-templates qui utilisent `Text::` ou `Route::` doivent donc déclarer leurs propres imports.

## Fichiers concernés

- `admin/tmpl/about/audit_report.php`
- `admin/tmpl/about/installed_plugins.php`
- `admin/tmpl/about/js_libraries.php`
- `admin/tmpl/about/log.php`
- `admin/tmpl/about/php_libraries.php`
- `admin/tmpl/about/repair_workflow.php`
- `admin/tmpl/about/version_summary.php`

## Validation

- [x] `php -l` sur tous les templates `admin/tmpl/about/*.php`
- [x] Contrôle ciblé : aucun template About utilisant `Text::` ou `Route::` sans import correspondant