### PR TITLE
Install xmllint in CI lint job

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -30,6 +30,9 @@ jobs:
             -not -path './admin/vendor/*' \
             -print0 | xargs -0 -n1 -P4 php -l > /dev/null
 
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libxml2-utils
+
       - name: Validate XML files
         run: |
           find . -type f -name '*.xml' \


### PR DESCRIPTION
ubuntu-latest runners do not ship libxml2-utils.