### PR TITLE
Fix mobile display + missing translation files

### DIFF
--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>Licensed under the GNU General Public License, version 2 or (at your option) any later version (SPDX: GPL-2.0-or-later).</license>
-    <version>6.1.7-RC65</version>
+    <version>6.1.7-RC66</version>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>
 
     <!-- ===================== -->

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,10 +6,10 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.7-RC65</version>
+		<version>6.1.7-RC66</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC65/com_contentbuilderng-6.1.7-RC65.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC66/com_contentbuilderng-6.1.7-RC66.zip</downloadurl>
 		<sha256>555e5424306074953cb76494869f6d4f3d2d95d8156e1afd6faec6f284d56a8f</sha256>
 		</downloads>
 		<tags>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,7 +10,7 @@ The project is a community modernization of the former Crosstec ContentBuilder
 extension. It is independent from the historical product and is provided without
 warranty.
 
-> ℹ️ **Note:** this documentation describes component version `6.1.7-RC65` (the
+> ℹ️ **Note:** this documentation describes component version `6.1.7-RC66` (the
 > `<version>` field in `com_contentbuilderng.xml`). Screens and options may change
 > between versions.
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -10,7 +10,7 @@ Le projet est issu de la migration et de la modernisation de l'ancien ContentBui
 de Crosstec. Il s'agit d'un projet communautaire, distinct du produit historique et
 fourni sans garantie.
 
-> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC65` du composant
+> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC66` du composant
 > (champ `<version>` du fichier `com_contentbuilderng.xml`). Les écrans et options
 > peuvent évoluer d'une version à l'autre.
 

--- a/media/css/details.css
+++ b/media/css/details.css
@@ -69,6 +69,9 @@
     .cbDetailsWrapper .cbToolBar.cbToolBar--top .btn{
         flex:1 1 calc(50% - .5rem);
         justify-content:center;
+        /* Libellés longs (fr/de) : on autorise le retour à la ligne
+           dans le bouton plutôt qu'un débordement du viewport. */
+        white-space:normal;
     }
 }
 

--- a/media/css/frontend.css
+++ b/media/css/frontend.css
@@ -48,6 +48,47 @@
     }
 }
 
+/* ── Pagination : replier les items sur petits écrans ────────────
+   Bootstrap ne pose pas flex-wrap sur ul.pagination : avec beaucoup
+   de pages, la barre déborde du viewport en portrait mobile.       */
+.pagination__wrapper .pagination {
+    flex-wrap: wrap;
+}
+
+/* ── Contenu d'enregistrement (details/edit/cartes) ──────────────
+   Le HTML des enregistrements est fourni par l'utilisateur : images
+   à largeur fixe, tableaux larges, URLs longues. On le contient dans
+   le viewport sans toucher au desktop.                             */
+.cbDetailsBody,
+.cbEditableBody,
+.cb-list-card-value {
+    overflow-wrap: break-word;
+    min-width: 0;
+}
+.cbDetailsBody img,
+.cbDetailsBody iframe,
+.cbDetailsBody video,
+.cbEditableBody img,
+.cbEditableBody iframe,
+.cbEditableBody video,
+.cb-list-card-value img {
+    max-width: 100%;
+    height: auto;
+}
+.cbDetailsBody table,
+.cbEditableBody table {
+    max-width: 100%;
+}
+@media (max-width: 767.98px) {
+    /* Filet de sécurité : un tableau saisi dans un enregistrement
+       scrolle dans son bloc au lieu d'élargir toute la page. */
+    .cbDetailsBody,
+    .cbEditableBody {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
 /* ── Utilitaires ─────────────────────────────────────────────────*/
 .cb-clear-right { clear: right; }
 

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
+++ b/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
@@ -7,7 +7,7 @@
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.7-RC65</version>
+    <version>6.1.7-RC66</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_STATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC65</version>
+  <version>6.1.7-RC66</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC65</version>
+  <version>6.1.7-RC66</version>
   <description><![CDATA[A dark mode theme based on Joomla 6]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/joomla6/joomla6.xml
+++ b/plugins/contentbuilderng_themes/joomla6/joomla6.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC65</version>
+  <version>6.1.7-RC66</version>
   <description><![CDATA[A Joomla 6 compatible theme]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Joomla6</namespace>
 

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC65</version>
+  <version>6.1.7-RC66</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
+++ b/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
+++ b/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/email/email.xml
+++ b/plugins/contentbuilderng_validation/email/email.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/equal/equal.xml
+++ b/plugins/contentbuilderng_validation/equal/equal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/notempty/notempty.xml
+++ b/plugins/contentbuilderng_validation/notempty/notempty.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC65</version>
+	<version>6.1.7-RC66</version>
 
 	<description>
 	<![CDATA[


### PR DESCRIPTION
# Correction de l'affichage responsive en portrait mobile (frontend)

## Problème

Sur téléphone en mode portrait (360–412 px de large), certaines vues frontend
de ContentBuilder NG provoquaient un débordement horizontal de la page.

## Causes identifiées

1. **Pagination personnalisée** (`site/layouts/contentbuilderng/list_pagination.php`) :
   `ul.pagination` Bootstrap n'a pas de `flex-wrap` par défaut — avec de
   nombreuses pages, la barre dépassait le viewport (elle est hors du
   conteneur scrollable du tableau).
2. **Contenu utilisateur** dans `.cbDetailsBody`, `.cbEditableBody` et les
   valeurs de cartes : images/iframes à largeur fixe, tableaux HTML saisis
   dans les enregistrements, URLs longues insécables.
3. **Toolbar de la vue details sur mobile** : boutons en `white-space: nowrap`
   avec `flex: 1 1 50%` — un libellé long (fr/de) débordait de son bouton.

Les tableaux des vues liste et publicforms étaient déjà correctement
encapsulés (`.cb-scroll-x`, `.table-responsive`) et ne nécessitaient rien.

## Corrections (CSS uniquement, aucun PHP modifié)

### `media/css/frontend.css` (fichier partagé, dépendance de list/details/edit)

- `flex-wrap: wrap` sur `.pagination__wrapper .pagination` ;
- containment du contenu d'enregistrement :
  - `overflow-wrap: break-word` + `min-width: 0` sur `.cbDetailsBody`,
    `.cbEditableBody` et `.cb-list-card-value` ;
  - `max-width: 100%; height: auto` sur les images, iframes et vidéos ;
  - `max-width: 100%` sur les tableaux ;
- sous 768 px uniquement : `overflow-x: auto` en filet de sécurité sur
  `.cbDetailsBody` / `.cbEditableBody` (un tableau large scrolle dans son
  bloc au lieu d'élargir la page).

### `media/css/details.css`

- Dans la media query mobile existante : `white-space: normal` sur les
  boutons de la toolbar sticky (repli du libellé au lieu d'un débordement).

## Impact

- Desktop et tablette inchangés : les règles sont soit additives et neutres,
  soit confinées à `@media (max-width: 767.98px)`.
- Aucun changement de logique métier ni de markup.

## Vérifications manuelles recommandées

Aux viewports 360×800, 390×844, 412×915 et 768×1024 :
- vue liste avec une pagination d'une quinzaine de pages ;
- fiche details contenant une image large et un tableau HTML ;
- toolbar details avec libellés français ;
- absence de scroll horizontal global sur chaque page.