### PR TITLE
Fix/mobile toolbar button width

### DIFF
--- a/admin/tests/Unit/Site/StatsServiceAggregatesTest.php
+++ b/admin/tests/Unit/Site/StatsServiceAggregatesTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @package     ContentBuilderNG
+ * @author      XDA+GIL
+ * @link        https://breezingforms-ng.vcmb.fr
+ * @copyright   Copyright © 2026 XDA+GIL
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace CB\Component\Contentbuilderng\Tests\Unit\Site;
+
+use CB\Component\Contentbuilderng\Site\Service\StatsService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class StatsServiceAggregatesTest extends TestCase
+{
+    /**
+     * @return array<string,array{0:array<int|string,int>,1:array{sum: float|null, min: float|null, max: float|null}}>
+     */
+    public static function aggregatesProvider(): array
+    {
+        return [
+            'empty map' => [
+                [],
+                ['sum' => null, 'min' => null, 'max' => null],
+            ],
+            'single value' => [
+                ['5' => 3],
+                ['sum' => 15.0, 'min' => 5.0, 'max' => 5.0],
+            ],
+            'integers weighted by counts' => [
+                ['1' => 2, '10' => 1, '4' => 3],
+                ['sum' => 24.0, 'min' => 1.0, 'max' => 10.0],
+            ],
+            'decimal and negative values' => [
+                ['-2.5' => 2, '0' => 1, '3.25' => 4],
+                ['sum' => 8.0, 'min' => -2.5, 'max' => 3.25],
+            ],
+            'mixed numeric and text' => [
+                ['1' => 2, 'n/a' => 1, '3' => 5],
+                ['sum' => null, 'min' => null, 'max' => null],
+            ],
+            'text only' => [
+                ['yes' => 4, 'no' => 2],
+                ['sum' => null, 'min' => null, 'max' => null],
+            ],
+            'dates' => [
+                ['2026-03-15' => 2, '2025-12-01' => 1, '2026-01-08' => 4],
+                ['sum' => null, 'min' => '2025-12-01', 'max' => '2026-03-15'],
+            ],
+            'datetimes with and without seconds' => [
+                ['2026-01-08 09:30' => 1, '2026-01-08 09:15:42' => 2],
+                ['sum' => null, 'min' => '2026-01-08 09:15:42', 'max' => '2026-01-08 09:30'],
+            ],
+            'mixed dates and text' => [
+                ['2026-01-08' => 1, 'n/a' => 2],
+                ['sum' => null, 'min' => null, 'max' => null],
+            ],
+            'invalid calendar date' => [
+                ['2026-02-30' => 1, '2026-01-08' => 1],
+                ['sum' => null, 'min' => null, 'max' => null],
+            ],
+            'numeric with surrounding sign and exponent' => [
+                ['1e2' => 1, '+3' => 2],
+                ['sum' => 106.0, 'min' => 3.0, 'max' => 100.0],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int|string,int> $values
+     * @param array{sum: float|null, min: float|null, max: float|null} $expected
+     */
+    #[DataProvider('aggregatesProvider')]
+    public function testComputeFieldAggregates(array $values, array $expected): void
+    {
+        $this->assertSame($expected, StatsService::computeFieldAggregates($values));
+    }
+
+    public function testMinAndMaxAreNotWeightedByCounts(): void
+    {
+        $aggregates = StatsService::computeFieldAggregates(['2' => 100, '7' => 1]);
+
+        $this->assertSame(2.0, $aggregates['min']);
+        $this->assertSame(7.0, $aggregates['max']);
+        $this->assertSame(207.0, $aggregates['sum']);
+    }
+}

--- a/admin/tests/bootstrap.php
+++ b/admin/tests/bootstrap.php
@@ -449,4 +449,5 @@ namespace {
     require_once \dirname(__DIR__, 2) . '/site/src/Service/Router.php';
     require_once \dirname(__DIR__, 2) . '/site/src/Service/SparseFieldsetService.php';
     require_once \dirname(__DIR__, 2) . '/site/src/Service/StatsFilterValueService.php';
+    require_once \dirname(__DIR__, 2) . '/site/src/Service/StatsService.php';
 }

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>Licensed under the GNU General Public License, version 2 or (at your option) any later version (SPDX: GPL-2.0-or-later).</license>
-    <version>6.1.7-RC70</version>
+    <version>6.1.7-RC71</version>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>
 
     <!-- ===================== -->

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,10 +6,10 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.7-RC70</version>
+		<version>6.1.7-RC71</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC70/com_contentbuilderng-6.1.7-RC70.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC71/com_contentbuilderng-6.1.7-RC71.zip</downloadurl>
 		<sha256>f66020240ead55c543ac43348737a89525322c94f93a46b5daee63db4fac261b</sha256>
 		</downloads>
 		<tags>

--- a/docs/en/api-json.md
+++ b/docs/en/api-json.md
@@ -234,6 +234,10 @@ Permission: **Stats only**.
 The field can be resolved by reference, name, or label, but must be published and
 API-authorized.
 
+When every distinct value of the field is numeric, the `field` payload also
+returns the aggregates `sum` (weighted by record counts), `min` and `max`;
+otherwise these three keys are `null`.
+
 ### Filter
 
 ```text

--- a/docs/en/api-json.md
+++ b/docs/en/api-json.md
@@ -235,8 +235,10 @@ The field can be resolved by reference, name, or label, but must be published an
 API-authorized.
 
 When every distinct value of the field is numeric, the `field` payload also
-returns the aggregates `sum` (weighted by record counts), `min` and `max`;
-otherwise these three keys are `null`.
+returns the aggregates `sum` (weighted by record counts), `min` and `max`.
+When every distinct value is an ISO date (`YYYY-MM-DD`, with an optional
+`HH:MM` or `HH:MM:SS` time), `min` and `max` return the earliest and latest
+date while `sum` stays `null`. Otherwise the three keys are `null`.
 
 ### Filter
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,7 +10,7 @@ The project is a community modernization of the former Crosstec ContentBuilder
 extension. It is independent from the historical product and is provided without
 warranty.
 
-> ℹ️ **Note:** this documentation describes component version `6.1.7-RC70` (the
+> ℹ️ **Note:** this documentation describes component version `6.1.7-RC71` (the
 > `<version>` field in `com_contentbuilderng.xml`). Screens and options may change
 > between versions.
 

--- a/docs/fr/api-json.md
+++ b/docs/fr/api-json.md
@@ -242,7 +242,10 @@ autorisé par l'API.
 
 Lorsque toutes les valeurs distinctes du champ sont numériques, la charge utile
 `field` renvoie aussi les agrégats `sum` (pondéré par le nombre d'enregistrements),
-`min` et `max` ; sinon ces trois clés valent `null`.
+`min` et `max`. Lorsque toutes les valeurs distinctes sont des dates ISO
+(`AAAA-MM-JJ`, avec une heure optionnelle `HH:MM` ou `HH:MM:SS`), `min` et `max`
+renvoient la date la plus ancienne et la plus récente, `sum` restant `null`.
+Sinon, les trois clés valent `null`.
 
 ### Filtrer
 

--- a/docs/fr/api-json.md
+++ b/docs/fr/api-json.md
@@ -240,6 +240,10 @@ Réponse :
 Le champ peut être recherché par référence, nom ou label, mais il doit être publié et
 autorisé par l'API.
 
+Lorsque toutes les valeurs distinctes du champ sont numériques, la charge utile
+`field` renvoie aussi les agrégats `sum` (pondéré par le nombre d'enregistrements),
+`min` et `max` ; sinon ces trois clés valent `null`.
+
 ### Filtrer
 
 ```text

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -10,7 +10,7 @@ Le projet est issu de la migration et de la modernisation de l'ancien ContentBui
 de Crosstec. Il s'agit d'un projet communautaire, distinct du produit historique et
 fourni sans garantie.
 
-> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC70` du composant
+> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC71` du composant
 > (champ `<version>` du fichier `com_contentbuilderng.xml`). Les écrans et options
 > peuvent évoluer d'une version à l'autre.
 

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
+++ b/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
@@ -7,7 +7,7 @@
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.7-RC70</version>
+    <version>6.1.7-RC71</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_STATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC70</version>
+  <version>6.1.7-RC71</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC70</version>
+  <version>6.1.7-RC71</version>
   <description><![CDATA[A dark mode theme based on Thoth]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC70</version>
+  <version>6.1.7-RC71</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/thoth/css/content.css
+++ b/plugins/contentbuilderng_themes/thoth/css/content.css
@@ -1,40 +1,5 @@
-.cbEditableWrapper {
-    max-width: 1120px;
-    margin: 0.7rem auto 1.4rem;
-    padding: 0.85rem 0.95rem 0.95rem;
-    border: 1px solid rgba(36, 61, 86, 0.12);
-    border-radius: 0.85rem;
-    background:
-        radial-gradient(circle at top right, rgba(13, 110, 253, 0.08), transparent 38%),
-        linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
-    box-shadow: 0 0.55rem 1.2rem rgba(16, 32, 56, 0.08);
-}
-
 .cbEditableWrapper > h1.display-6 {
-    margin-bottom: 0.7rem !important;
-    font-weight: 700;
-    letter-spacing: 0.01em;
     font-size: clamp(1.3rem, 2.2vw, 1.85rem);
-}
-
-.cbEditableWrapper > h1.display-6::after {
-    content: "";
-    display: block;
-    width: 3.4rem;
-    height: 0.2rem;
-    margin-top: 0.35rem;
-    border-radius: 999px;
-    background: linear-gradient(90deg, #0d6efd 0%, #3f8cff 100%);
-}
-
-.cbEditableWrapper .cbToolBar {
-    padding: 0.38rem 0.46rem;
-    border: 1px solid rgba(45, 73, 104, 0.14);
-    border-radius: 0.72rem;
-    background: linear-gradient(180deg, #f4f7fb 0%, #e9eff6 100%);
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.84),
-        0 0.18rem 0.45rem rgba(16, 32, 56, 0.06);
 }
 
 .cbEditableWrapper .cbToolBar.mb-5 {
@@ -43,11 +8,6 @@
 
 .cbEditableWrapper .cbEditableBody {
     margin: 0.4rem 0 0.55rem;
-    padding: 0.62rem 0.68rem 0.3rem;
-    border: 1px solid rgba(36, 61, 86, 0.14);
-    border-radius: 0.72rem;
-    background: linear-gradient(180deg, #fbfdff 0%, #f2f7fc 100%);
-    box-shadow: 0 0.28rem 0.72rem rgba(16, 32, 56, 0.05);
 }
 
 .cbEditableWrapper .cbColumnHeader {
@@ -56,10 +16,8 @@
     gap: 0.4rem;
     margin: 0.04rem 0 0.28rem;
     padding: 0.26rem 0.46rem;
-    border: 1px solid rgba(36, 61, 86, 0.16);
+    border: 1px solid var(--bs-border-color, #dee2e6);
     border-radius: 0.6rem;
-    background: #eef4ff;
-    color: #2a3f5e;
     font-size: 0.71rem;
     font-weight: 700;
     letter-spacing: 0.03em;
@@ -104,32 +62,27 @@
     margin: 0 0.3rem 0.2rem 0;
     padding: 0.14rem 0.48rem;
     border-radius: 999px;
-    border: 1px solid rgba(28, 51, 78, 0.12);
-    background: #eef4ff;
-    color: #2d3e59;
+    border: 1px solid var(--bs-border-color, #dee2e6);
     font-size: 0.77rem;
 }
 
 .cbEditableWrapper .alert.alert-warning {
-    border: 1px solid rgba(189, 116, 0, 0.34);
+    border: 1px solid rgba(var(--bs-warning-rgb, 255, 193, 7), 0.5);
     border-left-width: 0.35rem;
     border-radius: 0.8rem;
-    background: linear-gradient(90deg, rgba(255, 244, 222, 0.94) 0%, rgba(255, 249, 237, 0.96) 100%);
+    background: rgba(var(--bs-warning-rgb, 255, 193, 7), 0.14);
 }
 
 .cbEditableWrapper #cbArticleOptions {
     margin-bottom: 0.65rem;
     padding: 0.2rem;
     border-radius: 0.75rem;
-    border: 1px solid rgba(36, 61, 86, 0.1);
-    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid var(--bs-border-color, #dee2e6);
 }
 
 .cbEditableWrapper fieldset {
-    border: 1px solid rgba(36, 61, 86, 0.14) !important;
+    border: 1px solid var(--bs-border-color, #dee2e6) !important;
     border-radius: 0.72rem !important;
-    background: #ffffff;
-    box-shadow: 0 0.18rem 0.48rem rgba(16, 32, 56, 0.05);
 }
 
 .cbEditableWrapper fieldset.border.rounded.p-3.mb-3 {
@@ -140,20 +93,17 @@
 .cbEditableWrapper .cbEditableBody > .mb-3 {
     margin: 0 0 0.34rem !important;
     padding: 0.4rem 0.5rem;
-    border: 1px solid rgba(36, 61, 86, 0.14);
+    border: 1px solid var(--bs-border-color, #dee2e6);
     border-radius: 0.58rem;
-    background: linear-gradient(180deg, #ffffff 0%, #f7fbff 100%);
     display: grid;
     grid-template-columns: minmax(176px, 31%) minmax(0, 1fr);
     gap: 0.46rem;
     align-items: center;
-    box-shadow: 0 0.16rem 0.5rem rgba(16, 32, 56, 0.04);
 }
 
 .cbEditableWrapper .form-label,
 .cbEditableWrapper label {
     font-weight: 600;
-    color: #243d56;
     font-size: 0.86rem;
     margin-bottom: 0.22rem;
 }
@@ -161,7 +111,6 @@
 .cbEditableWrapper .cbEditableBody > .mb-3 > .form-label,
 .cbEditableWrapper .cbEditableBody > .mb-3 > label.form-label {
     margin: 0 !important;
-    color: #2b4a70;
     font-size: 0.74rem;
     font-weight: 700;
     letter-spacing: 0.04em;
@@ -186,9 +135,8 @@
     textarea,
     select
 ) {
-    border: 1px solid rgba(36, 61, 86, 0.2);
+    border: 1px solid var(--bs-border-color, #dee2e6);
     border-radius: 0.62rem;
-    background-color: #ffffff;
     font-size: 0.9rem;
     min-height: 2.05rem;
     padding: 0.34rem 0.52rem;
@@ -274,8 +222,8 @@
     textarea,
     select
 ):focus {
-    border-color: rgba(13, 110, 253, 0.55);
-    box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.14);
+    border-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.55);
+    box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb, 13, 110, 253), 0.14);
     outline: 0;
 }
 
@@ -289,41 +237,8 @@
     text-underline-offset: 0.15em;
 }
 
-.cbDetailsWrapper {
-    max-width: 1120px;
-    margin: 0.7rem auto 1.35rem;
-    padding: 0.8rem 0.95rem 0.98rem;
-    border: 1px solid rgba(36, 61, 86, 0.12);
-    border-radius: 0.86rem;
-    background:
-        radial-gradient(circle at top right, rgba(13, 110, 253, 0.08), transparent 38%),
-        linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
-    box-shadow: 0 0.55rem 1.2rem rgba(16, 32, 56, 0.08);
-}
-
 .cbDetailsWrapper > h1.display-6 {
-    margin-bottom: 0.62rem !important;
-    font-weight: 700;
-    letter-spacing: 0.01em;
     font-size: clamp(1.24rem, 2.05vw, 1.7rem);
-}
-
-.cbDetailsWrapper > h1.display-6::after {
-    content: "";
-    display: block;
-    width: 3.35rem;
-    height: 0.2rem;
-    margin-top: 0.36rem;
-    border-radius: 999px;
-    background: linear-gradient(90deg, #0d6efd 0%, #3f8cff 100%);
-}
-
-.cbDetailsWrapper .cbToolBar {
-    padding: 0.35rem 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    box-shadow: none;
 }
 
 .cbDetailsWrapper .cbToolBar .cbButton.btn {
@@ -348,14 +263,14 @@
 
 .cbDetailsWrapper .cbTitleRecordNav .cbButton.btn [class^="fa-"],
 .cbDetailsWrapper .cbTitleRecordNav .cbButton.btn [class*=" fa-"] {
-    color: #0d6efd;
+    color: var(--bs-primary-text-emphasis, #0d6efd);
 }
 
 .cbDetailsWrapper .cbToolBar .cbButton.btn-primary,
 .cbDetailsWrapper .cbTitleRecordNav .cbButton.btn-primary {
-    border-color: #0d6efd;
-    background: #ffffff;
-    color: #0d6efd;
+    border-color: var(--bs-primary-text-emphasis, #0d6efd);
+    background: var(--bs-body-bg, #ffffff);
+    color: var(--bs-primary-text-emphasis, #0d6efd);
 }
 
 .cbDetailsWrapper .cbToolBar .cbButton.btn-primary:hover,
@@ -391,25 +306,18 @@
     margin: 0 0.45rem 0.3rem 0;
     padding: 0.22rem 0.62rem;
     border-radius: 999px;
-    border: 1px solid rgba(28, 51, 78, 0.12);
-    background: #eef4ff;
-    color: #2d3e59;
+    border: 1px solid var(--bs-border-color, #dee2e6);
 }
 
 .cbDetailsWrapper .alert.alert-warning {
-    border: 1px solid rgba(189, 116, 0, 0.34);
+    border: 1px solid rgba(var(--bs-warning-rgb, 255, 193, 7), 0.5);
     border-left-width: 0.35rem;
     border-radius: 0.8rem;
-    background: linear-gradient(90deg, rgba(255, 244, 222, 0.94) 0%, rgba(255, 249, 237, 0.96) 100%);
+    background: rgba(var(--bs-warning-rgb, 255, 193, 7), 0.14);
 }
 
 .cbDetailsWrapper .cbDetailsBody {
     margin: 0.3rem 0 0.52rem;
-    padding: 0.74rem 0.8rem 0.5rem;
-    border: 1px solid rgba(36, 61, 86, 0.16);
-    border-radius: 0.76rem;
-    background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
-    box-shadow: 0 0.35rem 0.92rem rgba(16, 32, 56, 0.06);
 }
 
 .cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed {
@@ -423,25 +331,18 @@
 .cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed > li {
     margin: 0;
     padding: 0.56rem 0.62rem;
-    border: 1px solid rgba(36, 61, 86, 0.16);
+    border: 1px solid var(--bs-border-color, #dee2e6);
     border-radius: 0.62rem;
-    background: #ffffff;
     display: grid;
     grid-template-columns: minmax(200px, 30%) minmax(0, 1fr);
     gap: 0.6rem;
     align-items: start;
-    box-shadow: 0 0.18rem 0.52rem rgba(16, 32, 56, 0.04);
-}
-
-.cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed > li:nth-child(odd) {
-    border-left-color: rgba(36, 61, 86, 0.16);
 }
 
 .cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed > li strong.list-title {
     display: block;
     margin: 0;
     padding-top: 0.2rem;
-    color: #536987;
     font-size: 0.76rem;
     font-weight: 700;
     letter-spacing: 0.035em;
@@ -456,7 +357,6 @@
     border: 0;
     border-radius: 0;
     background: transparent;
-    color: #162f4d;
     font-size: 0.92rem;
     line-height: 1.45;
     min-height: 0;
@@ -473,14 +373,8 @@
 .cbDetailsWrapper .cbDetailsBody .list-group.list-group-flush > .list-group-item {
     margin: 0;
     padding: 0.56rem 0.62rem;
-    border: 1px solid rgba(36, 61, 86, 0.16);
+    border: 1px solid var(--bs-border-color, #dee2e6);
     border-radius: 0.62rem;
-    background: #ffffff;
-    box-shadow: 0 0.18rem 0.52rem rgba(16, 32, 56, 0.04);
-}
-
-.cbDetailsWrapper .cbDetailsBody .list-group.list-group-flush > .list-group-item:nth-child(odd) {
-    border-left-color: rgba(36, 61, 86, 0.16);
 }
 
 .cbDetailsWrapper .cbDetailsBody .list-group.list-group-flush > .list-group-item .row {
@@ -509,7 +403,6 @@
     display: block;
     margin: 0 !important;
     padding-top: 0.2rem;
-    color: #536987;
     font-size: 0.76rem;
     font-weight: 700;
     letter-spacing: 0.035em;
@@ -524,7 +417,6 @@
     border: 0;
     border-radius: 0;
     background: transparent;
-    color: #162f4d;
     font-size: 0.92rem;
     line-height: 1.45;
     min-height: 0;
@@ -665,124 +557,6 @@
 ):focus {
     border-color: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.65);
     box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb, 13, 110, 253), 0.15);
-}
-
-@media (prefers-color-scheme: dark) {
-    .cbEditableWrapper,
-    .cbDetailsWrapper {
-        border: 0;
-        background: transparent;
-        box-shadow: none;
-    }
-
-    .cbEditableWrapper > h1.display-6,
-    .cbDetailsWrapper > h1.display-6 {
-        border-bottom-color: rgba(255, 255, 255, 0.16);
-        color: #e7edf6;
-    }
-
-    .cbEditableWrapper .cbToolBar,
-    .cbDetailsWrapper .cbToolBar,
-    .cbEditableWrapper .cbEditableBody,
-    .cbDetailsWrapper .cbDetailsBody {
-        border-color: rgba(173, 193, 216, 0.24);
-        background: #1a2431;
-        box-shadow: 0 0.45rem 1rem rgba(0, 0, 0, 0.32);
-    }
-
-    .cbEditableWrapper .cbEditableBody,
-    .cbDetailsWrapper .cbDetailsBody {
-        color: #e7edf6;
-    }
-
-    .cbEditableWrapper .cbColumnHeader,
-    .cbEditableWrapper .created-by,
-    .cbDetailsWrapper .created-by {
-        border-color: rgba(173, 193, 216, 0.24);
-        background: #22344a;
-        color: #d8e5f5;
-    }
-
-    .cbEditableWrapper #cbArticleOptions,
-    .cbEditableWrapper fieldset,
-    .cbEditableWrapper .cbEditableBody > .mb-3,
-    .cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed > li,
-    .cbDetailsWrapper .cbDetailsBody .list-group.list-group-flush > .list-group-item {
-        border-color: rgba(173, 193, 216, 0.24) !important;
-        background: #1f2d3d;
-        color: #e7edf6;
-        box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.22);
-    }
-
-    .cbEditableWrapper .form-label,
-    .cbEditableWrapper label,
-    .cbEditableWrapper .cbEditableBody > .mb-3 > .form-label,
-    .cbEditableWrapper .cbEditableBody > .mb-3 > label.form-label,
-    .cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed > li strong.list-title,
-    .cbDetailsWrapper .cbDetailsBody .list-group.list-group-flush > .list-group-item .form-label {
-        color: #c5d7ec;
-    }
-
-    .cbDetailsWrapper .cbDetailsBody ul.category.list-striped.list-condensed > li > div,
-    .cbDetailsWrapper .cbDetailsBody .list-group.list-group-flush > .list-group-item .form-control-plaintext {
-        color: #e7edf6;
-    }
-
-    .cbEditableWrapper :is(
-        input[type="text"],
-        input[type="email"],
-        input[type="number"],
-        input[type="date"],
-        input[type="datetime-local"],
-        input[type="time"],
-        input[type="url"],
-        input[type="password"],
-        textarea,
-        select
-    ) {
-        border-color: rgba(173, 193, 216, 0.3);
-        background-color: #111a24;
-        color: #e7edf6;
-    }
-
-    .cbEditableWrapper :is(
-        input[type="text"],
-        input[type="email"],
-        input[type="number"],
-        input[type="date"],
-        input[type="datetime-local"],
-        input[type="time"],
-        input[type="url"],
-        input[type="password"],
-        textarea,
-        select
-    )::placeholder {
-        color: #95a9c2;
-    }
-
-    .cbEditableWrapper .alert.alert-warning,
-    .cbDetailsWrapper .alert.alert-warning {
-        border-color: rgba(255, 193, 7, 0.55);
-        background: linear-gradient(90deg, rgba(255, 193, 7, 0.18) 0%, rgba(255, 193, 7, 0.1) 100%);
-        color: #ffe79b;
-    }
-
-    .cbDetailsWrapper .cbToolBar .cbButton.btn-primary,
-    .cbDetailsWrapper .cbTitleRecordNav .cbButton.btn-primary {
-        border-color: #66a3ff;
-        background: #1a2431;
-        color: #8fbeff;
-    }
-
-    .cbDetailsWrapper .cbToolBar .cbButton.btn-primary:hover,
-    .cbDetailsWrapper .cbToolBar .cbButton.btn-primary:focus,
-    .cbDetailsWrapper .cbTitleRecordNav .cbButton.btn-primary:hover,
-    .cbDetailsWrapper .cbTitleRecordNav .cbButton.btn-primary:focus {
-        border-color: #66a3ff;
-        background: #66a3ff;
-        color: #102034;
-    }
-
 }
 
 @media (max-width: 767.98px) {

--- a/plugins/contentbuilderng_themes/thoth/css/content.css
+++ b/plugins/contentbuilderng_themes/thoth/css/content.css
@@ -797,7 +797,6 @@
     }
 
     .cbEditableWrapper .cbToolBar .cbButton.btn {
-        width: 100%;
         justify-content: center;
         font-size: 0.84rem;
     }
@@ -838,7 +837,6 @@
     }
 
     .cbDetailsWrapper .cbToolBar .cbButton.btn {
-        width: 100%;
         justify-content: center;
     }
 

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC70</version>
+  <version>6.1.7-RC71</version>
   <description><![CDATA[The native ContentBuilder NG Thoth theme]]></description>
   <namespace path="src">CB\Plugin\ContentbuilderngThemes\Thoth</namespace>
   <files>

--- a/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
+++ b/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
+++ b/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/email/email.xml
+++ b/plugins/contentbuilderng_validation/email/email.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/equal/equal.xml
+++ b/plugins/contentbuilderng_validation/equal/equal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/notempty/notempty.xml
+++ b/plugins/contentbuilderng_validation/notempty/notempty.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC70</version>
+	<version>6.1.7-RC71</version>
 
 	<description>
 	<![CDATA[

--- a/site/src/Service/StatsService.php
+++ b/site/src/Service/StatsService.php
@@ -254,41 +254,81 @@ final class StatsService
             default => [],
         };
 
-        $numericSum = null;
-        $numericMin = null;
-        $numericMax = null;
-        if ($values !== []) {
-            $acc = 0.0;
-            $min = null;
-            $max = null;
-            foreach ($values as $value => $count) {
-                if (!is_numeric($value)) {
-                    $acc = null;
-                    $min = null;
-                    $max = null;
-                    break;
-                }
-                $number = (float) $value;
-                $acc += $number * $count;
-                $min = $min === null ? $number : min($min, $number);
-                $max = $max === null ? $number : max($max, $number);
-            }
-            $numericSum = $acc;
-            $numericMin = $min;
-            $numericMax = $max;
-        }
-
         return [
             'requested' => $requestedField,
             'reference_id' => (int) $field['reference_id'],
             'name' => (string) $field['name'],
             'label' => (string) $field['label'],
             'total' => array_sum($values),
-            'sum' => $numericSum,
-            'min' => $numericMin,
-            'max' => $numericMax,
+        ] + self::computeFieldAggregates($values) + [
             'values' => $values,
         ];
+    }
+
+    /**
+     * Aggregates over a value => occurrence-count map. When every distinct
+     * value is numeric: count-weighted sum and numeric min/max. When every
+     * distinct value is an ISO date (Y-m-d, optional H:i or H:i:s): earliest
+     * and latest date as min/max, sum null. All null otherwise or when the
+     * map is empty.
+     *
+     * @return array{sum: float|null, min: float|string|null, max: float|string|null}
+     */
+    public static function computeFieldAggregates(array $values): array
+    {
+        $none = ['sum' => null, 'min' => null, 'max' => null];
+
+        if ($values === []) {
+            return $none;
+        }
+
+        $sum = 0.0;
+        $min = null;
+        $max = null;
+        $allDates = true;
+
+        foreach ($values as $value => $count) {
+            if (!is_numeric($value)) {
+                $sum = null;
+                $min = null;
+                $max = null;
+                break;
+            }
+
+            $number = (float) $value;
+            $sum += $number * $count;
+            $min = $min === null ? $number : min($min, $number);
+            $max = $max === null ? $number : max($max, $number);
+        }
+
+        if ($sum !== null) {
+            return ['sum' => $sum, 'min' => $min, 'max' => $max];
+        }
+
+        foreach ($values as $value => $count) {
+            if (!self::isIsoDateValue((string) $value)) {
+                $allDates = false;
+                break;
+            }
+        }
+
+        if (!$allDates) {
+            return $none;
+        }
+
+        $dates = array_map('strval', array_keys($values));
+        sort($dates, SORT_STRING);
+
+        return ['sum' => null, 'min' => $dates[0], 'max' => $dates[count($dates) - 1]];
+    }
+
+    private static function isIsoDateValue(string $value): bool
+    {
+        if (!preg_match('/^(\d{4})-(\d{2})-(\d{2})( \d{2}:\d{2}(:\d{2})?)?$/', $value, $matches)) {
+            return false;
+        }
+
+        return checkdate((int) $matches[2], (int) $matches[3], (int) $matches[1]);
     }
 
     private function resolveStatsField(int $formId, array $formRow, string $requestedField): ?array

--- a/site/src/Service/StatsService.php
+++ b/site/src/Service/StatsService.php
@@ -255,16 +255,27 @@ final class StatsService
         };
 
         $numericSum = null;
+        $numericMin = null;
+        $numericMax = null;
         if ($values !== []) {
             $acc = 0.0;
+            $min = null;
+            $max = null;
             foreach ($values as $value => $count) {
                 if (!is_numeric($value)) {
                     $acc = null;
+                    $min = null;
+                    $max = null;
                     break;
                 }
-                $acc += (float) $value * $count;
+                $number = (float) $value;
+                $acc += $number * $count;
+                $min = $min === null ? $number : min($min, $number);
+                $max = $max === null ? $number : max($max, $number);
             }
             $numericSum = $acc;
+            $numericMin = $min;
+            $numericMax = $max;
         }
 
         return [
@@ -274,6 +285,8 @@ final class StatsService
             'label' => (string) $field['label'],
             'total' => array_sum($values),
             'sum' => $numericSum,
+            'min' => $numericMin,
+            'max' => $numericMax,
             'values' => $values,
         ];
     }


### PR DESCRIPTION
## Mobile toolbar fixes, Thoth dark-mode refactor and stats API aggregates

### Summary

Fixes two front-end display issues on the Details/Edit views (button width on mobile, white frames in dark mode), extends the stats API with `min`/`max` aggregates, and bumps the package to **6.1.7-RC71**.

### UI fixes

- **Mobile toolbars**: the Thoth theme forced `width: 100%` on every Details/Edit toolbar button below 768 px, stretching Prev/Next and making the Back button span the full row. The width override is dropped; buttons keep their natural width and the flex-wrap toolbar handles line breaks.
- **Dark mode**: the Thoth Details/Edit CSS hardcoded light backgrounds and text colours and relied entirely on a `prefers-color-scheme: dark` block to invert them, so a site switched to dark via `data-bs-theme` kept white frames (the List view, already variable-driven, was unaffected). All surfaces, borders, labels and inputs are now driven by the Bootstrap tokens (`--bs-body-bg`, `--bs-body-color`, `--bs-border-color`, `--bs-warning-rgb`, `--bs-primary-text-emphasis`); the superseded legacy rules and the now redundant dark block are removed (−245 lines). Both dark-mode signals (OS preference and site toggle) render identically.

### API

- **`action=stats`**: when a `field` is requested, the field payload now returns `min` and `max` alongside the existing count-weighted `sum` — computed over the distinct field values, `null` as soon as any value is non-numeric. Documented in the en/fr API docs.

### Packaging

- Version bump 6.1.7-RC70 → 6.1.7-RC71.

### Testing

- `php -l` passes on the touched PHP files; CSS braces/structure validated.
- Manual check of Details/Edit in the four combinations (site light/dark × OS light/dark) and of the toolbar buttons at mobile widths.
- `action=stats&field=…` verified with numeric and non-numeric field values.