### PR TITLE
Suppress the admin template's external-link icon on the Preview button

### DIFF
--- a/admin/src/View/Form/HtmlView.php
+++ b/admin/src/View/Form/HtmlView.php
@@ -87,6 +87,9 @@ class HtmlView extends BaseHtmlView
             . 'height:48px;'
             . 'vertical-align:middle;'
             . '}'
+            // The admin template adds an external-link icon to every target="_blank"
+            // anchor; the Preview button already has its own eye icon for that.
+            . '#toolbar-link::before{content:none;}'
         );
 
 

--- a/admin/src/View/Storage/HtmlView.php
+++ b/admin/src/View/Storage/HtmlView.php
@@ -67,7 +67,10 @@ class HtmlView extends BaseHtmlView
                     width:48px;
                     height:48px;
                     vertical-align:middle;
-                }'
+                }
+                /* The admin template adds an external-link icon to every target="_blank"
+                   anchor; the Preview button already has its own eye icon for that. */
+                #toolbar-link::before{content:none;}'
             );
         }    
             


### PR DESCRIPTION
The Atum admin template adds a Font Awesome external-link icon to every a[target="_blank"] via a global ::before rule, so the Preview button showed that icon in addition to its own eye icon. Scope an override to the button's own id (#toolbar-link::before{content:none}) in both Form and Storage edit screens, keeping target="_blank" (the preview should still open in a new tab) while dropping the redundant icon.