### PR TITLE
Match the List preview banner styling to Details/Edit

### DIFF
--- a/plugins/contentbuilderng_themes/thoth/css/list.css
+++ b/plugins/contentbuilderng_themes/thoth/css/list.css
@@ -47,7 +47,18 @@
     border-color:rgba(var(--bs-primary-rgb,13,110,253),.65);
     box-shadow:0 0 0 .25rem rgba(var(--bs-primary-rgb,13,110,253),.15)
 }
+.cbPreviewBanner.alert.alert-warning{
+    border:1px solid rgba(var(--bs-warning-rgb,255,193,7),.5);
+    border-left-width:.35rem;
+    border-radius:.8rem;
+    background:rgba(var(--bs-warning-rgb,255,193,7),.14)
+}
 @media (prefers-color-scheme: dark){
+    html:not([data-bs-theme="light"]) .cbPreviewBanner.alert.alert-warning{
+        border-color:rgba(255,193,7,.55);
+        background:linear-gradient(90deg,rgba(255,193,7,.18) 0%,rgba(255,193,7,.1) 100%);
+        color:#ffe79b
+    }
     body{
         background-color:#0f1722;
         color:#e7edf6;

--- a/site/tmpl/list/default.php
+++ b/site/tmpl/list/default.php
@@ -444,7 +444,7 @@ $cbListInitScriptVersion = is_file($cbListInitScriptPath) ? (string) filemtime($
 		?>
 	<?php endif; ?>
 	<?php if ($isAdminPreview || $directStorageMode): ?>
-			<div class="alert alert-warning d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+			<div class="alert alert-warning cbPreviewBanner d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
 				<span>
 					<strong><?php echo Text::_('COM_CONTENTBUILDERNG_PREVIEW_MODE'); ?></strong>
 					<?php if ($directStorageMode) : ?>


### PR DESCRIPTION
The list view's preview-mode alert had no theme styling of its own (unlike Details/Edit, whose wrapper-scoped .alert-warning rules give it a softer border/background and a proper dark-mode look), so it fell back to plain Bootstrap defaults and looked inconsistent. Add a stable cbPreviewBanner class to the List banner and mirror the same light and dark-mode declarations already used for Details/Edit.