### PR TITLE
Populate the form-source object on the Details view, restoring owner …

### DIFF
--- a/admin/composer.lock
+++ b/admin/composer.lock
@@ -785,7 +785,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-04T07:00:23+00:00"
+            "time": "2026-07-05T07:00:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -1,6 +1,6 @@
 <extension type="component" method="upgrade" version="6.0">
     <name>COM_CONTENTBUILDERNG</name>
-    <creationDate>2026-07-04</creationDate>
+    <creationDate>2026-07-05</creationDate>
     <author>XDA+GIL</author>
     <authorEmail>bf@vcmb.fr</authorEmail>
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Download</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Image Scale</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG Permission Observer</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Rating</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
+++ b/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
     <name>ContentBuilder NG - Content - Stats</name>
-    <creationDate>2026-07-04</creationDate>
+    <creationDate>2026-07-05</creationDate>
     <author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_listaction" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - List Action - Trash</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_listaction" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - List Action - Untrash</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_submit" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Submit - Sample</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -2,7 +2,7 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Blank</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-04</creationDate>
+  <creationDate>2026-07-05</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -2,7 +2,7 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Dark</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-04</creationDate>
+  <creationDate>2026-07-05</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -2,7 +2,7 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Khepri</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-04</creationDate>
+  <creationDate>2026-07-05</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -2,7 +2,7 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Thoth</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-04</creationDate>
+  <creationDate>2026-07-05</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>

--- a/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
+++ b/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Date is Valid</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
+++ b/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Date Not Before</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_validation/email/email.xml
+++ b/plugins/contentbuilderng_validation/email/email.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Email</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_validation/equal/equal.xml
+++ b/plugins/contentbuilderng_validation/equal/equal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Equal</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_validation/notempty/notempty.xml
+++ b/plugins/contentbuilderng_validation/notempty/notempty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Not Empty</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_verify" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify - Pass-Through</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_verify" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify - PayPal</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="6.0" method="upgrade">
 	<name>ContentBuilder NG System</name>
-	<creationDate>2026-07-04</creationDate>
+	<creationDate>2026-07-05</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>

--- a/site/src/View/Details/HtmlView.php
+++ b/site/src/View/Details/HtmlView.php
@@ -433,6 +433,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->show_page_heading = $subject->show_page_heading;
 		$this->tpl = $subject->template;
+		$this->form = $subject->form ?? null;
 		$this->form_name = $subject->name ?? '';
 		$this->page_title = $subject->page_title;
 		$this->created = $subject->created;


### PR DESCRIPTION
…Edit

The Details HtmlView declares protected $form but never assigns it, even though DetailsModel::getData() already computes it as $data->form (the FormSourceFactory-resolved object exposing isOwner()). The template's owner-based Edit button check reads $this->form, so it always evaluated to null - $ownerEditAllowed was unconditionally false regardless of the visitor's actual ownership of the record. Assign $this->form = $subject->form ?? null (?? keeps the direct-storage payload, which has no 'form' key, safe). Most visibly noticed while using the admin preview-as-user feature to test "own" edit permissions, but the bug affects real front-end owners too.