### PR TITLE
Fix illegible debug panel tables in dark mode

### DIFF
--- a/media/css/debug-panel.css
+++ b/media/css/debug-panel.css
@@ -66,6 +66,15 @@
         color: #f6cdd3;
         background: rgba(234, 134, 143, .12);
     }
+
+    .cb-debug-details .table {
+        --bs-table-bg: transparent;
+        --bs-table-striped-bg: rgba(234, 134, 143, .07);
+        --bs-table-striped-color: #e7edf6;
+        --bs-table-color: #e7edf6;
+        --bs-table-border-color: rgba(234, 134, 143, .25);
+        color: #e7edf6;
+    }
 }
 
 html[data-bs-theme="dark"] .cb-debug-details {
@@ -83,4 +92,13 @@ html[data-bs-theme="dark"] .cb-debug-details[open] > summary {
 html[data-bs-theme="dark"] .cb-debug-details code {
     color: #f6cdd3;
     background: rgba(234, 134, 143, .12);
+}
+
+html[data-bs-theme="dark"] .cb-debug-details .table {
+    --bs-table-bg: transparent;
+    --bs-table-striped-bg: rgba(234, 134, 143, .07);
+    --bs-table-striped-color: #e7edf6;
+    --bs-table-color: #e7edf6;
+    --bs-table-border-color: rgba(234, 134, 143, .25);
+    color: #e7edf6;
 }


### PR DESCRIPTION
## Summary

- `.cb-debug-details` (the front-end debug panel) already paints its own dark background/text under both dark-mode signals (OS `prefers-color-scheme` and an explicit `data-bs-theme` toggle), but the two `.table-striped` tables it contains (published fields, and the current request's log entries — "Logs de la requête courante") kept Bootstrap's light default table variables, producing light-grey striped rows with light text on top: illegible over the dark panel background.
- Override `--bs-table-bg` / `--bs-table-striped-bg` / `--bs-table-color` / `--bs-table-border-color` scoped to `.cb-debug-details .table`, mirroring the panel's own dual dark-mode signal handling. Covers both tables, not just the logs one.

## Test plan

- [x] CSS brace balance validated
- [x] `vendor/bin/phpunit`: 286 tests, 858 assertions, green
- [ ] Manual: enable debug mode on the front-end, open the debug panel in dark mode, confirm both tables (fields, logs) are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)