### PR TITLE
Fix/group field selection

### DIFF
--- a/admin/composer.lock
+++ b/admin/composer.lock
@@ -785,7 +785,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-08T07:00:23+00:00"
+            "time": "2026-07-09T07:00:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/admin/src/Service/InstallerService.php
+++ b/admin/src/Service/InstallerService.php
@@ -362,6 +362,53 @@ final class InstallerService
         }
     }
 
+    /**
+     * Removes legacy plugin language files sitting flat in the plugin element
+     * folder (e.g. plugins/content/contentbuilderng_download/en-GB.plg_....ini),
+     * a naming convention superseded by language/<lang>/plg_....ini. Joomla's
+     * Language::load() never reads the flat location, so these files are inert,
+     * but leftover copies are misleading during troubleshooting and are removed
+     * on every install/update.
+     */
+    public function removeLegacyPluginLanguageFiles(): void
+    {
+        $languageTags = ['en-GB', 'fr-FR', 'de-DE'];
+        $pluginRoot = JPATH_PLUGINS;
+
+        if (!is_dir($pluginRoot)) {
+            return;
+        }
+
+        $globPatterns = [];
+        foreach ($languageTags as $tag) {
+            // plugins/<folder>/<element>/<lang>.plg_....ini (all shipped plugins are one level deep)
+            $globPatterns[] = $pluginRoot . '/*/*/' . $tag . '.plg_*contentbuilderng*.ini';
+            // Defensive: cover a hypothetical flat single-level plugin too.
+            $globPatterns[] = $pluginRoot . '/*/' . $tag . '.plg_*contentbuilderng*.ini';
+        }
+
+        $matches = [];
+        foreach ($globPatterns as $pattern) {
+            $matches = array_merge($matches, glob($pattern) ?: []);
+        }
+
+        foreach (array_unique($matches) as $match) {
+            try {
+                if (!is_file($match)) {
+                    continue;
+                }
+
+                if (File::delete($match)) {
+                    $this->log("[OK] Removed legacy plugin language file {$match}.");
+                } else {
+                    $this->log("[WARNING] Failed to remove legacy plugin language file {$match}.", Log::WARNING);
+                }
+            } catch (\Throwable $e) {
+                $this->log("[WARNING] Failed removing legacy plugin language file {$match}: " . $e->getMessage(), Log::WARNING);
+            }
+        }
+    }
+
     public function ensureAdminMenuRootNodeExists(): void
     {
         $db = $this->db();

--- a/admin/src/Service/TemplateRenderService.php
+++ b/admin/src/Service/TemplateRenderService.php
@@ -430,7 +430,94 @@ class TemplateRenderService
         ];
     }
 
-    private function renderReadonlyGroupField(object $form, string $elementId, string $elementType, string $value): string
+    private function normalizeGroupComparisonValue(string $value): string
+    {
+        $value = str_replace(["\r\n", "\r", "\u{00A0}"], ["\n", "\n", ' '], $value);
+
+        return trim(preg_replace('/\s+/u', ' ', $value) ?? $value);
+    }
+
+    /**
+     * Resolves which group option values are selected in a stored record value.
+     * Options are matched greedily (longest first) against the whole value, so
+     * option values containing the separator (commas) or line breaks are
+     * recognised as a whole instead of being split apart.
+     */
+    private function matchSelectedGroupValues(array $optionValues, string $storedValue): array
+    {
+        $normalizedOptions = [];
+
+        foreach ($optionValues as $optionValue) {
+            $optionValue = trim((string) $optionValue);
+            $normalized = $this->normalizeGroupComparisonValue($optionValue);
+
+            if ($normalized !== '') {
+                $normalizedOptions[$normalized] = $optionValue;
+            }
+        }
+
+        if ($normalizedOptions === []) {
+            return [];
+        }
+
+        uksort($normalizedOptions, static fn(string $a, string $b): int => mb_strlen($b) <=> mb_strlen($a));
+
+        $remaining = $this->normalizeGroupComparisonValue($storedValue);
+        $selected = [];
+
+        while ($remaining !== '') {
+            foreach ($normalizedOptions as $normalized => $original) {
+                $length = mb_strlen($normalized);
+
+                if (mb_substr($remaining, 0, $length) === $normalized) {
+                    $selected[] = $original;
+                    $remaining = ltrim(mb_substr($remaining, $length), " \t\n,");
+                    continue 2;
+                }
+            }
+
+            $nextSeparator = strpos($remaining, ',');
+
+            if ($nextSeparator === false) {
+                break;
+            }
+
+            $remaining = ltrim(substr($remaining, $nextSeparator + 1));
+        }
+
+        return array_values(array_unique($selected));
+    }
+
+    /**
+     * Resolves which options are selected for an editable group/select field.
+     * Order of precedence: values re-posted after a failed validation, then
+     * the exact recValues array from the record source (when the source can
+     * provide one, e.g. BreezingForms), then a best-effort match against the
+     * flattened, comma-joined stored value.
+     */
+    private function resolveEditableGroupValues(
+        array $groupDefinition,
+        ?array $failedValues,
+        $elementReferenceId,
+        array $item,
+        bool $hasRecords,
+        $defaultValue
+    ): array {
+        if ($failedValues !== null && isset($failedValues[$elementReferenceId]) && is_array($failedValues[$elementReferenceId])) {
+            return array_map(static fn($failedValue): string => trim((string) $failedValue), $failedValues[$elementReferenceId]);
+        }
+
+        if ($hasRecords && isset($item['values']) && is_array($item['values'])) {
+            return array_map(static fn($v): string => trim((string) $v), $item['values']);
+        }
+
+        return $this->matchSelectedGroupValues(
+            array_map('strval', array_keys($groupDefinition)),
+            (string) ($hasRecords ? $item['value'] : $defaultValue)
+        );
+    }
+
+    private function renderReadonlyGroupField(object $form, string $elementId, string $elementType, string $value, ?array $exactValues = null): string
     {
         if (!method_exists($form, 'isGroup') || !method_exists($form, 'getGroupDefinition') || !$form->isGroup($elementId)) {
             return '';
@@ -441,7 +528,9 @@ class TemplateRenderService
             return '';
         }
 
-        $selectedValues = array_map('trim', explode(',', $value));
+        $selectedValues = $exactValues !== null
+            ? array_values(array_unique(array_map(static fn($v): string => trim((string) $v), $exactValues)))
+            : $this->matchSelectedGroupValues(array_map('strval', array_keys($groupDefinition)), $value);
         if ($elementType === 'select') {
             $selectedLabels = [];
 
@@ -750,7 +839,7 @@ class TemplateRenderService
                     && $item->recValue != ''
                     && in_array($elementType, ['radiogroup', 'checkboxgroup', 'select'], true)
                 ) {
-                    $renderedGroupValue = $this->renderReadonlyGroupField($form, (string) $item->recElementId, $elementType, (string) $item->recValue);
+                    $renderedGroupValue = $this->renderReadonlyGroupField($form, (string) $item->recElementId, $elementType, (string) $item->recValue, property_exists($item, 'recValues') ? $item->recValues : null);
 
                     if ($renderedGroupValue !== '') {
                         $itemValue = $renderedGroupValue;
@@ -1020,6 +1109,7 @@ class TemplateRenderService
                 }
             }
             $items[$item->recName]['value'] = ($item->recValue ? $item->recValue : '');
+            $items[$item->recName]['values'] = property_exists($item, 'recValues') ? $item->recValues : null;
         }
 
         $hasRecords = true;
@@ -1036,6 +1126,7 @@ class TemplateRenderService
                 $items[$name]['id'] = $elementId;
                 $items[$name]['label'] = $labels[$elementId];
                 $items[$name]['value'] = '';
+                $items[$name]['values'] = null;
             }
         }
 
@@ -1214,19 +1305,12 @@ class TemplateRenderService
                     if ($form->isGroup($item['id'])) {
                         $groupdef = $form->getGroupDefinition($item['id']);
                         $i = 0;
-                        $sep = $options->seperator;
-                        $group = explode($sep, $failedValues !== null && isset($failedValues[$element['reference_id']]) && is_array($failedValues[$element['reference_id']]) ? implode($sep, $failedValues[$element['reference_id']]) : ($hasRecords ? $item['value'] : $element['default_value']));
+                        $group = $this->resolveEditableGroupValues($groupdef, $failedValues, $element['reference_id'], $item, $hasRecords, $element['default_value']);
                         $theItem = '<input name="cb_' . $item['id'] . '[]" type="hidden" value="cbGroupMark"/>';
                         $theItem .= '<div class="cbFormField cbGroupFields d-flex flex-wrap align-items-center gap-3">';
                         foreach ($groupdef as $value => $label) {
-                            $checked = '';
+                            $checked = in_array(trim((string) $value), $group, true) ? ' checked="checked"' : '';
                             $for = $i != 0 ? '_' . $i : '';
-                            foreach ($group as $selectedValue) {
-                                if (trim($value) == trim($selectedValue)) {
-                                    $checked = ' checked="checked"';
-                                    break;
-                                }
-                            }
                             $theItem .= '<div style="' . ($options->horizontal_length ? 'width: ' . $options->horizontal_length . ';' : '') . '" class="cbGroupField form-check form-check-inline d-inline-flex align-items-center gap-1 mb-0"><input class="form-check-input mt-0" id="cb_' . $item['id'] . $for . '" name="cb_' . $item['id'] . '[]" type="' . ($elementType == 'checkboxgroup' ? 'checkbox' : 'radio') . '" value="' . htmlspecialchars(trim($value), ENT_QUOTES, 'UTF-8') . '"' . $checked . '/> <label class="form-check-label" for="cb_' . $item['id'] . $for . '">' . htmlspecialchars(trim($label), ENT_QUOTES, 'UTF-8') . '</label> </div>';
                             $i++;
                         }
@@ -1241,19 +1325,12 @@ class TemplateRenderService
                     $options->length = $options->length ?? '';
                     if ($form->isGroup($item['id'])) {
                         $groupdef = $form->getGroupDefinition($item['id']);
-                        $sep = $options->seperator;
                         $multi = $options->multiple;
-                        $group = explode($sep, $failedValues !== null && isset($failedValues[$element['reference_id']]) && is_array($failedValues[$element['reference_id']]) ? implode($sep, $failedValues[$element['reference_id']]) : ($hasRecords ? $item['value'] : $element['default_value']));
+                        $group = $this->resolveEditableGroupValues($groupdef, $failedValues, $element['reference_id'], $item, $hasRecords, $element['default_value']);
                         $theItem = '<input name="cb_' . $item['id'] . '[]" type="hidden" value="cbGroupMark"/>';
                         $theItem .= '<div class="cbFormField cbSelectField"><select class="form-select form-select-sm" id="cb_' . $item['id'] . '" ' . ($options->length ? 'style="width:' . $options->length . ';" ' : '') . 'name="cb_' . $item['id'] . '[]"' . ($multi ? ' multiple="multiple"' : '') . '>';
                         foreach ($groupdef as $value => $label) {
-                            $checked = '';
-                            foreach ($group as $selectedValue) {
-                                if (trim($value) == trim($selectedValue)) {
-                                    $checked = ' selected="selected"';
-                                    break;
-                                }
-                            }
+                            $checked = in_array(trim((string) $value), $group, true) ? ' selected="selected"' : '';
                             $theItem .= '<option value="' . htmlspecialchars(trim($value), ENT_QUOTES, 'UTF-8') . '"' . $checked . '>' . htmlspecialchars(trim($label), ENT_QUOTES, 'UTF-8') . '</option>';
                         }
                         $theItem .= '</select></div>';

--- a/admin/src/types/com_breezingforms.php
+++ b/admin/src/types/com_breezingforms.php
@@ -762,12 +762,26 @@ class contentbuilderng_com_breezingforms
 
         /////////////
         // Swapping rows to columns
+        $groupTypes = ['Radio Group', 'Radio Button', 'Checkbox Group', 'Checkbox', 'Select List'];
         $selectors = '';
         foreach ($elements as $element) {
+            $isGroupType = in_array($element['type'], $groupTypes, true);
+
             if ($element['type'] == 'Radio Button' || $element['type'] == 'Checkbox') {
                 $selectors .= "GROUP_CONCAT( ( Case When s.`name` = '{$element['name']}' Then s.`value` End ) Order By s.`id` SEPARATOR ', ' ) As `col{$element['id']}Value`,";
             } else {
                 $selectors .= "GROUP_CONCAT( ( Case When s.`element` = '{$element['id']}' Then s.`value` End ) Order By s.`id` SEPARATOR ', ' ) As `col{$element['id']}Value`,";
+            }
+
+            // Group-type elements also get a raw, unambiguously-separated value:
+            // the display column above joins multiple selections with ', ', which
+            // collides with option values that themselves contain a comma.
+            if ($isGroupType) {
+                if ($element['type'] == 'Radio Button' || $element['type'] == 'Checkbox') {
+                    $selectors .= "GROUP_CONCAT( ( Case When s.`name` = '{$element['name']}' Then s.`value` End ) Order By s.`id` SEPARATOR CHAR(31) ) As `col{$element['id']}Raw`,";
+                } else {
+                    $selectors .= "GROUP_CONCAT( ( Case When s.`element` = '{$element['id']}' Then s.`value` End ) Order By s.`id` SEPARATOR CHAR(31) ) As `col{$element['id']}Raw`,";
+                }
             }
         }
         $selectors = rtrim($selectors, ',');
@@ -821,6 +835,13 @@ class contentbuilderng_com_breezingforms
                 $out[$i]->recValue = '';
                 if (isset($colValues['col' . $element['id'] . 'Value'])) {
                     $out[$i]->recValue = $colValues['col' . $element['id'] . 'Value'];
+                }
+                if (isset($colValues['col' . $element['id'] . 'Raw'])) {
+                    $rawValue = (string) $colValues['col' . $element['id'] . 'Raw'];
+                    $out[$i]->recValues = $rawValue === '' ? [] : array_values(array_filter(
+                        array_map('trim', explode("\x1F", $rawValue)),
+                        static fn(string $v): bool => $v !== ''
+                    ));
                 }
                 $i++;
             }

--- a/admin/tmpl/about/extensions.php
+++ b/admin/tmpl/about/extensions.php
@@ -54,7 +54,7 @@ $plugins = is_array($this->plugins ?? null) ? $this->plugins : [];
                         <?php
                         $pluginId = (int) ($plugin['id'] ?? 0);
                         $pluginEditUrl = $pluginId > 0
-                            ? Route::_('index.php?option=com_plugins&view=plugin&layout=edit&extension_id=' . $pluginId, false)
+                            ? Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $pluginId, false)
                             : '';
                         ?>
                         <tr>

--- a/admin/tmpl/about/installed_plugins.php
+++ b/admin/tmpl/about/installed_plugins.php
@@ -84,7 +84,7 @@ $pluginNameFilter = (string) ($this->pluginNameFilter ?? '');
                                     <?php foreach ($this->plugins as $plugin) : ?>
                                         <?php
                                         $pluginId = (int) ($plugin['id'] ?? 0);
-                                        $pluginEditUrl = Route::_('index.php?option=com_plugins&view=plugin&layout=edit&extension_id=' . $pluginId, false);
+                                        $pluginEditUrl = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $pluginId, false);
                                         ?>
                                         <tr>
                                             <td>

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -1,12 +1,12 @@
 <extension type="component" method="upgrade" version="6.0">
     <name>COM_CONTENTBUILDERNG</name>
-    <creationDate>2026-07-08</creationDate>
+    <creationDate>2026-07-09</creationDate>
     <author>XDA+GIL</author>
     <authorEmail>bf@vcmb.fr</authorEmail>
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>Licensed under the GNU General Public License, version 2 or (at your option) any later version (SPDX: GPL-2.0-or-later).</license>
-    <version>6.1.7-RC77</version>
+    <version>6.1.7-RC78</version>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>
 
     <!-- ===================== -->

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,10 +6,10 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.7-RC77</version>
+		<version>6.1.7-RC78</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC77/com_contentbuilderng-6.1.7-RC77.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC78/com_contentbuilderng-6.1.7-RC78.zip</downloadurl>
 		<sha256>337b272cdb6eb26a5f9916e87b7c0b52bb77c9433bac0ff6526a252efece96e6</sha256>
 		</downloads>
 		<tags>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,7 +10,7 @@ The project is a community modernization of the former Crosstec ContentBuilder
 extension. It is independent from the historical product and is provided without
 warranty.
 
-> ℹ️ **Note:** this documentation describes component version `6.1.7-RC77` (the
+> ℹ️ **Note:** this documentation describes component version `6.1.7-RC78` (the
 > `<version>` field in `com_contentbuilderng.xml`). Screens and options may change
 > between versions.
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -10,7 +10,7 @@ Le projet est issu de la migration et de la modernisation de l'ancien ContentBui
 de Crosstec. Il s'agit d'un projet communautaire, distinct du produit historique et
 fourni sans garantie.
 
-> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC77` du composant
+> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC78` du composant
 > (champ `<version>` du fichier `com_contentbuilderng.xml`). Les écrans et options
 > peuvent évoluer d'une version à l'autre.
 

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Download</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_DOWNLOAD_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngDownload</namespace>

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Image Scale</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_IMAGE_SCALE_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngImageScale</namespace>

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG Permission Observer</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_PERMISSION_OBSERVER_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngPermissionObserver</namespace>

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Content - Rating</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_RATING_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngRating</namespace>

--- a/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
+++ b/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
     <name>ContentBuilder NG - Content - Stats</name>
-    <creationDate>2026-07-08</creationDate>
+    <creationDate>2026-07-09</creationDate>
     <author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.7-RC77</version>
+    <version>6.1.7-RC78</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_STATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="content" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_VERIFY_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngVerify</namespace>

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_listaction" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - List Action - Trash</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_listaction" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - List Action - Untrash</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_submit" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Submit - Sample</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Blank</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-08</creationDate>
+  <creationDate>2026-07-09</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC77</version>
+  <version>6.1.7-RC78</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Dark</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-08</creationDate>
+  <creationDate>2026-07-09</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC77</version>
+  <version>6.1.7-RC78</version>
   <description><![CDATA[A dark mode theme based on Thoth]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Khepri</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-08</creationDate>
+  <creationDate>2026-07-09</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC77</version>
+  <version>6.1.7-RC78</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -2,12 +2,12 @@
 <extension type="plugin" group="contentbuilderng_themes" method="upgrade">
   <name>ContentBuilder NG - Themes - Thoth</name>
   <author>XDA+GIL</author>
-  <creationDate>2026-07-08</creationDate>
+  <creationDate>2026-07-09</creationDate>
   <copyright>(C) 2026 XDA+GIL</copyright>
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC77</version>
+  <version>6.1.7-RC78</version>
   <description><![CDATA[The native ContentBuilder NG Thoth theme]]></description>
   <namespace path="src">CB\Plugin\ContentbuilderngThemes\Thoth</namespace>
   <files>

--- a/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
+++ b/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Date is Valid</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
+++ b/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Date Not Before</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/email/email.xml
+++ b/plugins/contentbuilderng_validation/email/email.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Email</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/equal/equal.xml
+++ b/plugins/contentbuilderng_validation/equal/equal.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Equal</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/notempty/notempty.xml
+++ b/plugins/contentbuilderng_validation/notempty/notempty.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_validation" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Validation - Not Empty</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_verify" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify - Pass-Through</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="contentbuilderng_verify" version="6.0" method="upgrade">
 	<name>ContentBuilder NG - Verify - PayPal</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
         <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="system" version="6.0" method="upgrade">
 	<name>ContentBuilder NG System</name>
-	<creationDate>2026-07-08</creationDate>
+	<creationDate>2026-07-09</creationDate>
 	<author>XDA+GIL</author>
     <license>GNU/GPL v2 or later https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</license>
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC77</version>
+	<version>6.1.7-RC78</version>
 
 	<description>PLG_SYSTEM_CONTENTBUILDERNG_SYSTEM_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\System\ContentbuilderngSystem</namespace>

--- a/script.php
+++ b/script.php
@@ -318,6 +318,7 @@ class com_contentbuilderngInstallerScript
                 // Cleanup old directories/files (best-effort)
                 $this->removeOldDirectories();
                 $this->removeObsoleteFiles();
+                $this->removeLegacyPluginLanguageFiles();
 
                 // Ensure media templates / upload dir
                 $this->ensureMediaListTemplateInstalled();
@@ -953,6 +954,11 @@ class com_contentbuilderngInstallerScript
     private function removeObsoleteFiles(): void
     {
         $this->installerService->removeObsoleteFiles();
+    }
+
+    private function removeLegacyPluginLanguageFiles(): void
+    {
+        $this->installerService->removeLegacyPluginLanguageFiles();
     }
 
     private function purgeStaleLanguageFiles(): void

--- a/site/src/Model/EditModel.php
+++ b/site/src/Model/EditModel.php
@@ -237,6 +237,22 @@ class EditModel extends BaseDatabaseModel
         $this->_data = null;
     }
 
+    /**
+     * Strips control bytes that must never be persisted in a group field value:
+     * NUL and the ASCII unit separator (0x1F). The latter is used internally by
+     * the BreezingForms source (com_breezingforms.php::getRecord()) as the
+     * unambiguous delimiter between multi-select values; a raw POST (the
+     * 'array' input filter applies no sanitisation) could otherwise smuggle a
+     * stray 0x1F into a stored value and corrupt that reconstruction later.
+     */
+    private function sanitizeGroupSubmissionValues(array $values): array
+    {
+        return array_map(
+            static fn($value): string => str_replace(["\x00", "\x1F"], '', (string) $value),
+            $values
+        );
+    }
+
     private function _buildQuery()
     {
         $isAdminPreview = $this->app->getInput()->getBool('cb_preview_ok', false);
@@ -954,6 +970,7 @@ var contentbuilderng = new function(){
                                 if (!is_array($groupValue)) {
                                     $groupValue = array($groupValue);
                                 }
+                                $groupValue = $this->sanitizeGroupSubmissionValues($groupValue);
                                 $value = array_values(array_filter($groupValue, static fn($v) => $v !== null && $v !== '' && $v !== 'cbGroupMark'));
                             } elseif (isset($the_fields[$id]['options']->allow_raw) && $the_fields[$id]['options']->allow_raw) {
                                 $value = $this->app->getInput()->post->get('cb_' . $id, null, 'raw');
@@ -1234,6 +1251,7 @@ var contentbuilderng = new function(){
                                         if (!is_array($groupValue)) {
                                             $groupValue = array($groupValue);
                                         }
+                                        $groupValue = $this->sanitizeGroupSubmissionValues($groupValue);
                                         $value = array_values(array_filter($groupValue, static fn($v) => $v !== null && $v !== '' && $v !== 'cbGroupMark'));
                                     } elseif (isset($the_fields[$id]['options']->allow_raw) && $the_fields[$id]['options']->allow_raw) {
                                         $value = $this->app->getInput()->post->get('cb_' . $id, '', 'raw');


### PR DESCRIPTION
## Résumé

Corrige un bug d'affichage des champs à choix (radio/checkbox/select) en mode Détail et Édition frontend, nettoie les fichiers de langue de plugin obsolètes lors de l'installation, et corrige les liens d'édition de plugin cassés sur l'écran « À propos ».

## Changements

### 1. Sélection radio/checkbox/select non affichée quand une valeur contient une virgule

**Fichiers :** `admin/src/Service/TemplateRenderService.php`, `admin/src/types/com_breezingforms.php`

Les valeurs de champs à choix étaient comparées via un `explode(',', $valeur)` naïf. Si une option contenait elle-même une virgule (ex. *« Week-end Mortagne-au-Perche (3 jours, 50 euros), vendredi... »*) ou si la valeur stockée contenait un retour à la ligne interne (particularité BreezingForms), la comparaison échouait silencieusement : aucun bouton radio/checkbox n'apparaissait coché, en Détail comme en Édition.

- Ajout de `matchSelectedGroupValues()` : appariement glouton (option la plus longue d'abord) de la valeur stockée contre les options connues, au lieu d'un découpage aveugle sur la virgule.
- Pour les vues issues de **BreezingForms**, ajout d'un tableau `recValues` exact (obtenu via un `GROUP_CONCAT` séparé par `CHAR(31)`), qui élimine complètement l'heuristique pour ces sources.
- Les vues **ContentBuilder NG natives** continuent d'utiliser le matcher, car leur stockage aplati la valeur en une seule colonne jointe par virgule dès l'enregistrement — la granularité est perdue en amont, pas seulement à la lecture.

### 2. Fichiers de langue de plugin obsolètes non nettoyés

**Fichiers :** `admin/src/Service/InstallerService.php`, `script.php`

Les anciennes versions livraient les traductions de plugin à plat (`plugins/<groupe>/<élément>/<lang>.plg_....ini`), une convention remplacée depuis par `language/<lang>/plg_....ini`. Joomla ne lit jamais l'ancien emplacement (chemin non concerné par `LanguageHelper::getLanguagePath()`), donc ces fichiers sont inertes — mais jamais supprimés, ce qui brouille le diagnostic en cas de souci de traduction.

- Nouvelle méthode `InstallerService::removeLegacyPluginLanguageFiles()`, appelée à chaque installation/mise à jour, limitée aux noms de fichiers contenant `contentbuilderng` (aucun risque pour un plugin tiers).

### 3. Liens d'édition de plugin cassés sur l'écran « À propos »

**Fichiers :** `admin/tmpl/about/extensions.php`, `admin/tmpl/about/installed_plugins.php`

Les liens ajoutés sur le nom du plugin pointaient directement vers `view=plugin&layout=edit`, ce qui contourne le verrou de session posé par `DisplayController::checkEditId()` de `com_plugins` — Joomla refusait l'accès avec *« Vous n'êtes pas autorisé à utiliser ce lien pour accéder directement à cette page »*.

- Les liens passent maintenant par `task=plugin.edit`, comme tous les liens « Éditer » natifs de Joomla.

## Tests effectués

- `php -l` sur tous les fichiers modifiés.
- Logique de correspondance de valeurs (`matchSelectedGroupValues`, explosion `recValues` via `CHAR(31)`) testée en isolation avec des scripts PHP ad hoc reproduisant les cas réels (valeur radio à virgules, retour ligne interne, sélection multiple, valeurs simples historiques, espaces insécables).
- Pas de test end-to-end dans un navigateur — à vérifier manuellement sur l'écran Détail/Édition d'un enregistrement et sur l'écran À propos → Extensions.

## Points de vigilance

- Le correctif des valeurs de groupe ne résout le problème **exactement** que pour les vues BreezingForms (tableau `recValues` exact). Pour les vues ContentBuilder NG natives, l'heuristique gloutonne reste nécessaire tant que le stockage n'évolue pas vers une vraie table de jointure (non traité ici, hors périmètre).
Résumé
Corrige un bug d'affichage des champs à choix (radio/checkbox/select) en mode Détail et Édition frontend, nettoie les fichiers de langue de plugin obsolètes lors de l'installation, et corrige les liens d'édition de plugin cassés sur l'écran « À propos ».