### PR TITLE
6.1.7-RC78 -> 6.1.7-RC79

### DIFF
--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>Licensed under the GNU General Public License, version 2 or (at your option) any later version (SPDX: GPL-2.0-or-later).</license>
-    <version>6.1.7-RC78</version>
+    <version>6.1.7-RC79</version>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>
 
     <!-- ===================== -->

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,10 +6,10 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.7-RC78</version>
+		<version>6.1.7-RC79</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC78/com_contentbuilderng-6.1.7-RC78.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC79/com_contentbuilderng-6.1.7-RC79.zip</downloadurl>
 		<sha256>a7efb59b6725bb0f580baad2cb9cae203484217ac623c48fc4094cd4909940a7</sha256>
 		</downloads>
 		<tags>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,7 +10,7 @@ The project is a community modernization of the former Crosstec ContentBuilder
 extension. It is independent from the historical product and is provided without
 warranty.
 
-> ℹ️ **Note:** this documentation describes component version `6.1.7-RC78` (the
+> ℹ️ **Note:** this documentation describes component version `6.1.7-RC79` (the
 > `<version>` field in `com_contentbuilderng.xml`). Screens and options may change
 > between versions.
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -10,7 +10,7 @@ Le projet est issu de la migration et de la modernisation de l'ancien ContentBui
 de Crosstec. Il s'agit d'un projet communautaire, distinct du produit historique et
 fourni sans garantie.
 
-> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC78` du composant
+> ℹ️ **Note :** cette documentation décrit la version `6.1.7-RC79` du composant
 > (champ `<version>` du fichier `com_contentbuilderng.xml`). Les écrans et options
 > peuvent évoluer d'une version à l'autre.
 

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_DOWNLOAD_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngDownload</namespace>

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_IMAGE_SCALE_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngImageScale</namespace>

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_PERMISSION_OBSERVER_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngPermissionObserver</namespace>

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_RATING_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngRating</namespace>

--- a/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
+++ b/plugins/content/contentbuilderng_stats/contentbuilderng_stats.xml
@@ -7,7 +7,7 @@
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.7-RC78</version>
+    <version>6.1.7-RC79</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_STATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_VERIFY_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngVerify</namespace>

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC78</version>
+  <version>6.1.7-RC79</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC78</version>
+  <version>6.1.7-RC79</version>
   <description><![CDATA[A dark mode theme based on Thoth]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC78</version>
+  <version>6.1.7-RC79</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC78</version>
+  <version>6.1.7-RC79</version>
   <description><![CDATA[The native ContentBuilder NG Thoth theme]]></description>
   <namespace path="src">CB\Plugin\ContentbuilderngThemes\Thoth</namespace>
   <files>

--- a/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
+++ b/plugins/contentbuilderng_validation/date_is_valid/date_is_valid.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
+++ b/plugins/contentbuilderng_validation/date_not_before/date_not_before.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/email/email.xml
+++ b/plugins/contentbuilderng_validation/email/email.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/equal/equal.xml
+++ b/plugins/contentbuilderng_validation/equal/equal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_validation/notempty/notempty.xml
+++ b/plugins/contentbuilderng_validation/notempty/notempty.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC78</version>
+	<version>6.1.7-RC79</version>
 
 	<description>PLG_SYSTEM_CONTENTBUILDERNG_SYSTEM_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\System\ContentbuilderngSystem</namespace>


### PR DESCRIPTION
Derniers commits
1. Fix SQL syntax error in BreezingForms group field raw value query
Fichier : admin/src/types/com_breezingforms.php

Corrige une régression introduite dans le correctif radio/checkbox/select précédent : GROUP_CONCAT(... SEPARATOR CHAR(31)) n'est pas une syntaxe valide en MySQL/MariaDB — la clause SEPARATOR exige un littéral chaîne, pas un appel de fonction. Le bug cassait l'affichage en mode Détail sur toutes les listes (erreur SQL 1064).

Remplacement par $db->quote(chr(31)), qui génère un littéral correctement échappé.
Aucun changement côté lecture (explode("\x1F", ...)), déjà cohérent avec cet octet.
2. Add regression guard for invalid GROUP_CONCAT SEPARATOR syntax, document MariaDB/MySQL dialect
Fichiers : AGENTS.md, admin/tests/Unit/Sql/GroupConcatSeparatorSyntaxTest.php

Empêche que ce type d'erreur ne se reproduise, à deux niveaux :

Test de garde statique : scanne admin/src, site/src et plugins à la recherche de toute clause SEPARATOR suivie d'un appel de fonction nu — le motif exact du bug précédent. Aucune connexion base réelle nécessaire ; validé pour échouer si le bug est réintroduit (reproduit puis corrigé pendant les tests).
Documentation : AGENTS.md précise désormais que tout SQL brut du projet cible MySQL/MariaDB spécifiquement, avec ce piège SEPARATOR cité en exemple.
3. 6.1.7-RC78 -> 6.1.7-RC79
Fichiers : 25 fichiers — manifestes des ~20 plugins, com_contentbuilderng.xml, com_contentbuilderng_update.xml, docs FR/EN

Bump de version mécanique (date de création + numéro de version), suivant le même patron que les bumps précédents (RC77→RC78, etc.). Aucun changement fonctionnel.