### PR TITLE
Fix RuntimeContextHelper application type at the root (PHPStan)

### DIFF
--- a/admin/src/Extension/ContentbuilderngComponent.php
+++ b/admin/src/Extension/ContentbuilderngComponent.php
@@ -27,6 +27,7 @@ use Joomla\CMS\Component\Router\RouterServiceTrait;
 use Joomla\CMS\Extension\MVCComponent;
 use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
 use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\Database\DatabaseInterface;
 use Psr\Container\ContainerInterface;
 use LogicException;
@@ -49,6 +50,9 @@ class ContentbuilderngComponent extends MVCComponent implements BootableExtensio
         // binds it in the component container before boot() runs, so it is
         // resolvable here. DatabaseInterface delegates to the global container.
         $app = $container->get(CMSApplicationInterface::class);
+        if (!$app instanceof CMSWebApplicationInterface) {
+            throw new LogicException('ContentBuilder NG can only boot behind the site or administrator web application.');
+        }
         $db = $container->get(DatabaseInterface::class);
         RuntimeContextHelper::initialize($app, $db);
 

--- a/admin/src/Helper/RuntimeContextHelper.php
+++ b/admin/src/Helper/RuntimeContextHelper.php
@@ -12,7 +12,7 @@ namespace CB\Component\Contentbuilderng\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseInterface;
 use LogicException;
@@ -25,26 +25,37 @@ use LogicException;
  * onAfterInitialise/onAfterRoute, installer steps) fall back lazily to the
  * global Factory — this helper and services/provider.php are the only
  * sanctioned Factory bridges of the component.
+ *
+ * Typed CMSWebApplicationInterface (not the narrower CMSApplicationInterface)
+ * because most consumers immediately call getDocument(), which only the web
+ * application interface declares; this component only ever runs behind the
+ * site or administrator web application, never a CLI/console app.
  */
 final class RuntimeContextHelper
 {
-    private static ?CMSApplicationInterface $app = null;
+    private static ?CMSWebApplicationInterface $app = null;
     private static ?DatabaseInterface $db = null;
 
-    public static function initialize(CMSApplicationInterface $app, DatabaseInterface $db): void
+    public static function initialize(CMSWebApplicationInterface $app, DatabaseInterface $db): void
     {
         self::$app = $app;
         self::$db = $db;
     }
 
-    public static function getApplication(): CMSApplicationInterface
+    public static function getApplication(): CMSWebApplicationInterface
     {
         if (self::$app === null) {
             try {
-                self::$app = Factory::getApplication();
+                $app = Factory::getApplication();
             } catch (\Throwable $exception) {
                 throw new LogicException('Runtime application context has not been initialized.', 0, $exception);
             }
+
+            if (!$app instanceof CMSWebApplicationInterface) {
+                throw new LogicException('Runtime application context is not a web application.');
+            }
+
+            self::$app = $app;
         }
 
         return self::$app;

--- a/plugins/contentbuilderng_themes/thoth/src/Extension/Thoth.php
+++ b/plugins/contentbuilderng_themes/thoth/src/Extension/Thoth.php
@@ -22,6 +22,7 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\CMS\Event\GenericEvent as Event;
 use Joomla\Event\SubscriberInterface;
 use CB\Component\Contentbuilderng\Administrator\Helper\Logger;
+use CB\Component\Contentbuilderng\Administrator\Helper\RuntimeContextHelper;
 
 final class Thoth extends CMSPlugin implements SubscriberInterface
 {
@@ -29,7 +30,7 @@ final class Thoth extends CMSPlugin implements SubscriberInterface
 
     private function useStyle(string $name, string $file): void
     {
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+        $wa = RuntimeContextHelper::getApplication()->getDocument()->getWebAssetManager();
         $assetName = 'plg_contentbuilderng_themes_thoth.' . $name;
 
         if (!$wa->assetExists('style', $assetName)) {


### PR DESCRIPTION
## Résumé

Le correctif précédent (#73) n'a traité qu'un symptôme : il a remplacé `$this->getApplication()->getDocument()` par `Factory::getApplication()->getDocument()` dans `Thoth.php`, mais `Factory::getApplication()` a le même type de retour trop étroit (`CMSApplicationInterface`, sans `getDocument()`) — PHPStan a rééchoué sur la même ligne après fusion (build #360).

En exécutant PHPStan localement (`admin/vendor/bin/phpstan`), la vraie cause est apparue : `phpstan-baseline.neon` tolère déjà 5 occurrences préexistantes de cette même erreur (dont `ContentbuilderngStats.php`, qui utilise le même motif) — ce n'est pas un motif qui « passe » PHPStan, c'est de la dette déjà connue et masquée.

## Cause racine

`RuntimeContextHelper::getApplication()` — le pont officiel du composant vers l'application courante — était typé `CMSApplicationInterface`, alors que la quasi-totalité de ses ~13 appelants enchaînent `->getDocument()`, méthode qui n'existe que sur `CMSWebApplicationInterface`. Ce composant ne tourne jamais qu'en application web (site ou admin), jamais en CLI.

## Changements

- `RuntimeContextHelper.php` : type élargi à `CMSWebApplicationInterface` (propriété, `initialize()`, `getApplication()`), avec vérification `instanceof` à l'exécution sur le repli `Factory::getApplication()`.
- `ContentbuilderngComponent::boot()` : même vérification avant `initialize()`.
- `Thoth.php` : bascule vers `RuntimeContextHelper::getApplication()` (le pont sanctionné), au lieu de `Factory::getApplication()`.

## Tests

- `admin/vendor/bin/phpstan analyse -c phpstan.neon.dist` : **0 erreur** (contre 1 avant).
- PHPUnit : **423 tests, 1736 assertions, tout vert**.

## Suivi non bloquant

Les 5 entrées de `phpstan-baseline.neon` pour ce même message sont probablement obsolètes maintenant — à confirmer par une régénération de baseline séparée.