### PR TITLE
Prevent sparse edit submissions from clearing fields

### DIFF
--- a/admin/tests/Unit/Model/EditSparseSubmissionTest.php
+++ b/admin/tests/Unit/Model/EditSparseSubmissionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CB\Component\Contentbuilderng\Tests\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+
+final class EditSparseSubmissionTest extends TestCase
+{
+    public function testFieldsAbsentFromPostAreExcludedFromSavedValues(): void
+    {
+        $model = file_get_contents(
+            dirname(__DIR__, 4) . '/site/src/Model/EditModel.php'
+        );
+
+        self::assertIsString($model);
+        self::assertStringContainsString(
+            "if (!\$this->app->getInput()->post->exists('cb_' . \$id)) {\n                                    continue;",
+            $model
+        );
+        self::assertStringContainsString('$values[$id] = $value;', $model);
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -955,12 +955,6 @@ parameters:
 			path: site/src/Model/EditModel.php
 
 		-
-			message: '#^Access to an undefined property CB\\Component\\Contentbuilderng\\Site\\Model\\EditModel\:\:\$_id\.$#'
-			identifier: property.notFound
-			count: 33
-			path: site/src/Model/EditModel.php
-
-		-
 			message: '#^Variable \$fields might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -957,7 +957,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property CB\\Component\\Contentbuilderng\\Site\\Model\\EditModel\:\:\$_id\.$#'
 			identifier: property.notFound
-			count: 32
+			count: 33
 			path: site/src/Model/EditModel.php
 
 		-

--- a/site/src/Controller/EditController.php
+++ b/site/src/Controller/EditController.php
@@ -165,6 +165,15 @@ class EditController extends BaseController
         }
 
         $model = $this->getEditModel(['ignore_request' => true]);
+        if (!$model->isEditableTemplateConfigured()) {
+            $link = Route::_('index.php?option=com_contentbuilderng&task=edit.display&id='
+                . $this->siteApp->getInput()->getInt('id', 0)
+                . '&record_id=' . $this->siteApp->getInput()->getCmd('record_id', '')
+                . '&Itemid=' . $this->siteApp->getInput()->getInt('Itemid', 0), false);
+            $this->setRedirect($link, Text::_('COM_CONTENTBUILDERNG_EDITABLE_TEMPLATE_NOT_SET'), 'error');
+            return;
+        }
+
         $id = $model->store();
 
         $submission_failed = $this->siteApp->getInput()->getBool('cb_submission_failed', false);
@@ -294,6 +303,20 @@ class EditController extends BaseController
         }
 
         $model = $this->getEditModel(['ignore_request' => true]);
+        if (!$model->isEditableTemplateConfigured()) {
+            $message = Text::_('COM_CONTENTBUILDERNG_EDITABLE_TEMPLATE_NOT_SET');
+            if ($this->isAjaxCall()) {
+                $this->respondAjax(false, $message);
+                return;
+            }
+
+            $this->setRedirect(Route::_('index.php?option=com_contentbuilderng&task=edit.display&id='
+                . $this->siteApp->getInput()->getInt('id', 0)
+                . '&record_id=' . $this->siteApp->getInput()->getCmd('record_id', '')
+                . '&Itemid=' . $this->siteApp->getInput()->getInt('Itemid', 0), false), $message, 'error');
+            return;
+        }
+
         $changedCount = (int) $model->change_list_states();
         $msg = Text::plural('COM_CONTENTBUILDERNG_N_STATES_CHANGED', $changedCount);
 

--- a/site/src/Model/DetailsModel.php
+++ b/site/src/Model/DetailsModel.php
@@ -97,13 +97,10 @@ class DetailsModel extends ListModel
 
         // ATTTENTION: ALSO DEFINED IN DETAILS CONTROLLER!
         if ($this->frontend && $app->getInput()->getInt('Itemid', 0)) {
-            $this->_menu_item = true;
-
-            // try menu item
-
             $menu = $app->getMenu();
             $item = $menu->getActive();
-            if (is_object($item)) {
+            if (is_object($item) && ($item->query['option'] ?? '') === $option) {
+                $this->_menu_item = true;
                 $params = $item->getParams();
                 $this->_show_back_button = MenuParamHelper::getResolvedMenuToggle(
                     $params,

--- a/site/src/Model/EditModel.php
+++ b/site/src/Model/EditModel.php
@@ -83,6 +83,7 @@ class EditModel extends BaseDatabaseModel
     private readonly ListSupportService $listSupportService;
     private readonly TemplateRenderService $templateRenderService;
 
+    private int $_id = 0;
     private $_record_id = 0;
 
     private $frontend = false;

--- a/site/src/Model/EditModel.php
+++ b/site/src/Model/EditModel.php
@@ -274,6 +274,20 @@ class EditModel extends BaseDatabaseModel
         return $this->getComponent()->getContainer()->get(DatabaseInterface::class);
     }
 
+    public function isEditableTemplateConfigured(): bool
+    {
+        $db = $this->getDatabase();
+        $formId = $this->_id;
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('editable_template'))
+            ->from($db->quoteName('#__contentbuilderng_forms'))
+            ->where($db->quoteName('id') . ' = :formId')
+            ->bind(':formId', $formId, ParameterType::INTEGER);
+        $db->setQuery($query);
+
+        return trim((string) $db->loadResult()) !== '';
+    }
+
     private function createMailer()
     {
         return $this->getComponent()->getContainer()->get(MailerFactoryInterface::class)->createMailer();
@@ -319,6 +333,7 @@ class EditModel extends BaseDatabaseModel
                 $data->limited_options = $this->frontend ? $data->limited_article_options_fe : $data->limited_article_options;
                 $data->form_id = $this->_id;
                 $data->record_id = $this->_record_id;
+                $data->editable_template_configured = trim((string) ($data->editable_template ?? '')) !== '';
                 if ($data->type && $data->reference_id) {
 
                     // article options
@@ -1242,6 +1257,10 @@ var contentbuilderng = new function(){
                             if (isset($the_upload_fields[$id]) && $id == $the_upload_fields[$id]['reference_id']) {
                                 // nothing, done above already
                             } else {
+                                if (!$this->app->getInput()->post->exists('cb_' . $id)) {
+                                    continue;
+                                }
+
                                 $f = null;
 
                                 if (isset($the_html_fields[$id])) {

--- a/site/src/View/Edit/HtmlView.php
+++ b/site/src/View/Edit/HtmlView.php
@@ -44,6 +44,7 @@ class HtmlView extends BaseHtmlView
     public $event;
     public $record_id = 0;
     public $edit_by_type = false;
+    public bool $editable_template_configured = false;
     public $latest = false;
     public $back_button = false;
     public $created = null;
@@ -747,7 +748,7 @@ class HtmlView extends BaseHtmlView
             if (is_object($this->item)) {
                 $props = [
                     'theme_css', 'theme_js', 'show_page_heading', 'page_title', 'record_id',
-                    'edit_by_type', 'latest', 'back_button', 'created', 'created_by',
+                    'edit_by_type', 'editable_template_configured', 'latest', 'back_button', 'created', 'created_by',
                     'modified', 'modified_by', 'create_articles', 'apply_button_title',
                     'save_button_title', 'id', 'article_options', 'article_settings',
                     'limited_options', 'show_id_column', 'toc', 'tpl',

--- a/site/tmpl/details/print.php
+++ b/site/tmpl/details/print.php
@@ -49,7 +49,7 @@ if (trim($themeJs) !== '') {
         <span class="fa-solid fa-print me-1" aria-hidden="true"></span><?php echo Text::_('COM_CONTENTBUILDERNG_PRINT') ?>
     </button>
     <button class="btn btn-sm btn-outline-secondary" onclick="self.close()">
-        <?php echo Text::_('COM_CONTENTBUILDERNG_CLOSE') ?>
+        <span class="icon-times me-1" aria-hidden="true"></span><?php echo Text::_('COM_CONTENTBUILDERNG_CLOSE') ?>
     </button>
 </div>
 <h1 class="display-6 mb-4">

--- a/site/tmpl/edit/default.php
+++ b/site/tmpl/edit/default.php
@@ -138,7 +138,7 @@ if ($previewFormName === '') {
 }
 $previewFormName = htmlspecialchars($previewFormName, ENT_QUOTES, 'UTF-8');
 $previewConfigTabLabel = Text::sprintf('COM_CONTENTBUILDERNG_PREVIEW_CONFIG_TAB', Text::_('COM_CONTENTBUILDERNG_PREVIEW_TAB_EDITABLE_TEMPLATE'));
-$editableTemplateMissing = $isAdminPreview && trim((string) ($this->tpl ?? '')) === '';
+$editableTemplateMissing = !$this->editable_template_configured;
 $previewFrontendPermissionKey = in_array((string) $recordId, ['', '0'], true)
     ? 'COM_CONTENTBUILDERNG_PERM_NEW'
     : 'COM_CONTENTBUILDERNG_PERM_EDIT';
@@ -206,7 +206,7 @@ $stateOptions = (array) ($this->states ?? []);
 $currentStateId = (int) (($this->state_ids ?? [])[$recordId] ?? 0);
 $currentStateTitle = trim((string) (($this->state_titles ?? [])[$recordId] ?? ''));
 $currentStateBadgeStyle = $getStateBadgeStyle((string) $recordId, (array) ($this->state_colors ?? []));
-$showStateControl = (int) ($this->list_state ?? 0) === 1 && count($stateOptions) > 0 && $hasRecord;
+$showStateControl = !$editableTemplateMissing && (int) ($this->list_state ?? 0) === 1 && count($stateOptions) > 0 && $hasRecord;
 $showRatingControl = (int) ($this->list_rating ?? 0) === 1 && (int) ($this->rating_slots ?? 0) > 0 && $hasRecord;
 $backHref = ($backToList || !$hasRecord) ? $listHref : $detailsHref;
 if (!isset($showBack)) {
@@ -875,7 +875,7 @@ PreviewColorModeHelper::registerAssets($wa, $previewColorMode);
         <button type="button" class="btn btn-sm btn-primary cbButton cbArticleSettingsButton" title="<?php echo htmlspecialchars(Text::_('COM_CONTENTBUILDERNG_EDIT_ARTICLE_SETTINGS_TOOLTIP'), ENT_QUOTES, 'UTF-8'); ?>" onclick="var o=document.getElementById('cbArticleOptions');o.hidden=!o.hidden;"><span class="fa-solid fa-gear me-1" aria-hidden="true"></span><?php echo Text::_('COM_CONTENTBUILDERNG_SHOW_ARTICLE_SETTINGS'); ?></button>
     <?php
     }
-    if (($edit_allowed || $new_allowed) && !$this->edit_by_type) {
+    if (($edit_allowed || $new_allowed) && !$this->edit_by_type && !$editableTemplateMissing) {
     ?>
         <button type="button" class="btn btn-sm btn-primary cbButton cbSaveButton" title="<?php echo htmlspecialchars(Text::_('COM_CONTENTBUILDERNG_EDIT_SAVE_TOOLTIP'), ENT_QUOTES, 'UTF-8'); ?>" onclick="document.getElementById('contentbuilderng_task').value='edit.save';contentbuilderng.onSubmit();">
             <span class="fa-solid fa-floppy-disk me-1" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

- preserve editable field values when their `cb_<id>` input is absent from a sparse edit submission
- distinguish an omitted field from a field explicitly submitted with an empty value
- hide Save and state controls when the Editable Template is not configured
- reject direct save and state-change requests server-side when the Editable Template is empty
- keep the ContentBuilderNG form title in direct print views instead of inheriting an unrelated active menu title such as Home
- add the native Joomla close icon to the print toolbar

## Root cause

The earlier sparse-submission fix preserved missing values during the first preparation pass. A second validation pass then read the same absent inputs with an empty-string default and added those empty values to the save payload. This cleared editable fields that were not rendered in the Editable Template, while non-editable fields remained untouched.

The second pass now skips every `cb_<id>` input that does not exist in POST data. Inputs that are present and intentionally empty are still saved as empty.

## Safety

An empty Editable Template can no longer expose mutating controls. The controller also enforces the same rule so direct requests cannot bypass the UI.

## Validation

- PHP syntax checks passed for all changed PHP files
- PHPUnit: **424 tests, 1,739 assertions**
- added `EditSparseSubmissionTest` to guard the omitted-field behavior
- verified the empty-template edit screen for form 17 / record 203: no Save button and no state selector
- verified a direct save attempt leaves the record data hash unchanged
- verified the print URL uses **Contactez le VCMB** for both the document title and heading
- verified the Joomla close icon is rendered in the print toolbar