### PR TITLE
Improve community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible problem in a supported release
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve ContentBuilder NG. Do not report security vulnerabilities here; use private vulnerability reporting instead.
+  - type: input
+    id: version
+    attributes:
+      label: ContentBuilder NG version
+      description: Use the exact version from the installed package.
+      placeholder: 6.x.x
+    validations:
+      required: true
+  - type: input
+    id: joomla
+    attributes:
+      label: Joomla version
+      placeholder: 6.x.x
+    validations:
+      required: true
+  - type: input
+    id: php
+    attributes:
+      label: PHP version
+      placeholder: 8.3.x
+    validations:
+      required: true
+  - type: input
+    id: database
+    attributes:
+      label: Database
+      description: Include the product and exact version.
+      placeholder: MySQL 8.4.x or MariaDB 11.x
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem
+      description: Describe what happened and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, numbered sequence.
+      placeholder: |
+        1. Configure …
+        2. Open …
+        3. Observe …
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and screenshots
+      description: Remove credentials, personal data and other sensitive information.
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mention relevant extensions, templates, overrides or recent migrations.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I reproduced this with the latest published ContentBuilder NG release.
+          required: true
+        - label: I searched existing issues and pull requests for duplicates.
+          required: true
+        - label: This report does not contain a security vulnerability or sensitive data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/vcmb-cyclo/com_contentbuilderng/security/advisories/new
+    about: Report suspected vulnerabilities privately.
+  - name: User documentation
+    url: https://github.com/vcmb-cyclo/com_contentbuilderng/tree/main/docs
+    about: Check the English and French user documentation before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Propose an improvement to ContentBuilder NG
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Explain the user need rather than only the proposed implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior and, when relevant, its Joomla workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or other approaches.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add mockups, examples or links that clarify the request.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and pull requests for similar requests.
+          required: true
+        - label: This request targets Joomla 6 and the currently supported ContentBuilder NG release.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+Describe the problem and the solution. Link related issues with `Fixes #…` when
+applicable.
+
+## Verification
+
+List the tests and manual checks performed.
+
+## UI changes
+
+Add before-and-after screenshots for visible changes, or write “Not applicable”.
+
+## Checklist
+
+- [ ] The change targets Joomla 6, PHP 8.3+ and MySQL/MariaDB only.
+- [ ] Native Joomla 6 APIs and MVC conventions are respected.
+- [ ] The change is focused and contains no unrelated refactoring.
+- [ ] Relevant automated tests were added or updated.
+- [ ] Relevant local checks pass.
+- [ ] User-facing strings use translation keys.
+- [ ] Translation changes are aligned in `en-GB`, `fr-FR` and `de-DE`.
+- [ ] Documentation was updated when behavior or requirements changed.
+- [ ] No credentials, personal data or generated artifacts are included.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our Commitment
+
+We are committed to making participation in ContentBuilder NG a respectful,
+welcoming and harassment-free experience for everyone, regardless of
+background, identity, experience or level of expertise.
+
+## Expected Behavior
+
+Examples of behavior that contributes to a positive community include:
+
+- communicating with empathy, patience and respect;
+- giving and receiving constructive technical feedback;
+- focusing discussion on the project and its users;
+- acknowledging mistakes and learning from them;
+- respecting differing viewpoints and experiences.
+
+## Unacceptable Behavior
+
+The following behavior is not tolerated:
+
+- harassment, threats, intimidation or discriminatory language;
+- personal attacks, insults, trolling or sustained disruption;
+- sexualized language or unwelcome attention;
+- publishing another person's private information without permission;
+- any conduct that would reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement
+
+Project maintainers may edit, remove or reject comments, commits, issues,
+pull requests and other contributions that violate this code. They may also
+temporarily or permanently restrict participation when necessary.
+
+Report conduct concerns privately to the project maintainers using the contact
+details published on their GitHub profiles. Reports will be reviewed promptly
+and handled as confidentially as practical. Maintainers involved in an incident
+must not participate in its review.
+
+## Scope
+
+This code applies in all project spaces and whenever someone is publicly
+representing the project or its community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to ContentBuilder NG
+
+Thank you for helping improve ContentBuilder NG.
+
+## Before You Start
+
+- Use GitHub Discussions or an issue to confirm the scope of substantial
+  changes before implementation.
+- Search existing issues and pull requests to avoid duplicates.
+- Report vulnerabilities privately according to
+  [SECURITY.md](SECURITY.md).
+- Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Supported Development Environment
+
+Contributions must target:
+
+- Joomla 6 only;
+- PHP 8.3 or later;
+- MySQL or MariaDB only.
+
+Use native Joomla 6 APIs and modern PHP. Do not add compatibility code for
+older Joomla or PHP versions.
+
+## Development Setup
+
+Install the PHP and frontend development dependencies:
+
+```bash
+cd admin
+composer install
+cd ..
+npm ci
+```
+
+See [TESTING.md](TESTING.md) for package and Joomla integration testing.
+
+## Making Changes
+
+- Keep changes focused and avoid unrelated refactoring.
+- Respect Joomla MVC separation and prefer native Joomla UI patterns.
+- Keep custom CSS and JavaScript minimal.
+- Build SQL with Joomla's query builder. Raw SQL must use MySQL/MariaDB syntax.
+- Route every user-facing Joomla string through a translation key.
+- Update `en-GB`, `fr-FR` and `de-DE` together when translations change.
+- Add or update tests for behavior changes and regressions.
+- Never commit credentials, generated packages, dependency directories or
+  local configuration.
+
+## Verification
+
+Run the checks relevant to your change. The main local commands are:
+
+```bash
+cd admin
+vendor/bin/phpunit -c phpunit.xml.dist
+cd ..
+admin/vendor/bin/phpstan analyse -c phpstan.neon.dist --no-progress
+npm run lint:css
+python3 scripts/check-translations.py
+```
+
+For packaging or installer changes, also run:
+
+```bash
+scripts/build-package.sh
+scripts/validate-package.sh build/com_contentbuilderng-<version>.zip
+scripts/joomla-install-smoke.sh build/com_contentbuilderng-<version>.zip
+```
+
+The integration test requires Docker.
+
+## Pull Requests
+
+- Use a clear title and explain the problem and the chosen solution.
+- Link related issues.
+- Describe how the change was tested.
+- Include screenshots for visible UI changes.
+- Keep the branch current and ensure all required GitHub checks pass.
+- Update documentation when behavior or requirements change.
+
+By contributing, you agree that your contribution is licensed under
+`GPL-2.0-or-later`.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Only **GitHub Releases** should be considered stable and suitable for production
 
 ---
 
+## Contributing
+
+Bug reports, feature proposals and pull requests are welcome. Before
+contributing, read the **[contribution guidelines](CONTRIBUTING.md)** and the
+**[code of conduct](CODE_OF_CONDUCT.md)**.
+
+Use the repository issue forms for bugs and feature requests. Security issues
+must be reported privately as described in the **[security policy](SECURITY.md)**.
+
+---
+
 ## Migration Notes
 
 The component installer performs all supported database, extension, plugin and menu migrations automatically. Do not uninstall the legacy component before installing the ContentBuilder NG package.
@@ -52,6 +63,14 @@ Manual SQL is not required during a normal migration. It is reserved for diagnos
 4. Install via the Joomla Extension Manager
 
 > The automatically generated GitHub **Source code (zip)** archive is a development snapshot, not an installable Joomla package.
+
+---
+
+## License
+
+ContentBuilder NG is licensed under the
+**[GNU General Public License version 2 or later](LICENSE)**
+(`GPL-2.0-or-later`).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,32 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Security fixes are provided for the latest published GitHub release.
+Development snapshots and older releases are not supported.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported |
+| --- | --- |
+| Latest GitHub release | Yes |
+| Older releases | No |
+| `main` and source archives | No |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Do not open a public issue for a suspected vulnerability.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Use [GitHub private vulnerability reporting](https://github.com/vcmb-cyclo/com_contentbuilderng/security/advisories/new)
+and include:
+
+- the affected ContentBuilder NG, Joomla, PHP and database versions;
+- the required configuration and permissions;
+- reproducible steps or a minimal proof of concept;
+- the expected and observed impact;
+- any suggested remediation, if available.
+
+You should receive an acknowledgement within seven days. The maintainers will
+then assess the report, keep you informed of material progress and coordinate
+disclosure when a fix is available. Reports may be declined when the behavior
+is not reproducible, is outside the supported version or does not cross a
+security boundary.
+
+Please allow a reasonable remediation period before publishing details.


### PR DESCRIPTION
## Summary

- replace the placeholder security policy with supported-version and private-reporting guidance
- add contribution and conduct guidelines tailored to Joomla 6, PHP 8.3+, and MySQL/MariaDB
- add structured bug and feature issue forms
- add a pull request checklist
- link contribution, security, and licensing information from the README

## Why

The repository community profile was incomplete, and the existing security
policy still contained GitHub's generic placeholder content.

## Impact

Contributors receive clearer submission and verification guidance, maintainers
receive better structured reports, and vulnerabilities are directed to private
reporting.

## Checks

- parsed all issue-form YAML files successfully
- `git diff --check`
- verified referenced local documentation paths
