### PR TITLE
Corriger la perte du tri CBList à la pagination

### DIFF
--- a/admin/tests/Unit/Site/EmbeddedListSortPaginationTest.php
+++ b/admin/tests/Unit/Site/EmbeddedListSortPaginationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CB\Component\Contentbuilderng\Tests\Unit\Site;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guard for a production defect: paging an embedded CBList reset
+ * it to the view's own ordering, which reads as the sort inverting when that
+ * ordering runs the other way.
+ *
+ * Nothing here can be caught by a type checker or a linter. The bug was a
+ * guard written with isset(), which is true for the empty string that the
+ * pagination links serialised — so the model believed the visitor had chosen
+ * an ordering and discarded the {CBList sort="..."} one. These are structural
+ * assertions on the two files that have to agree with each other, in the same
+ * spirit as DebugPermissionHelperCallSitesTest.
+ */
+final class EmbeddedListSortPaginationTest extends TestCase
+{
+    private const MODEL = 'site/src/Model/ListModel.php';
+    private const PAGINATION_LAYOUT = 'site/layouts/contentbuilderng/list_pagination.php';
+
+    public function testEmbeddedSortGuardTestsEmptinessRatherThanPresence(): void
+    {
+        $source = $this->read(self::MODEL);
+
+        self::assertStringContainsString(
+            "\$requestedOrdering === '' && \$requestedFullordering === ''",
+            $source,
+            'The embedded sort must only stand down for a NON-EMPTY requested ordering. '
+            . 'isset() is true for the empty string the pagination links carry, which silently '
+            . 'discarded the {CBList sort="..."} order on every page change.'
+        );
+        self::assertStringNotContainsString(
+            "!isset(\$list['ordering']) && !isset(\$list['fullordering'])",
+            $source,
+            'The isset()-based guard is the regression itself — see this test\'s docblock.'
+        );
+    }
+
+    public function testPaginationLinksOmitTheOrderingWhileNoSortIsActive(): void
+    {
+        $source = $this->read(self::PAGINATION_LAYOUT);
+
+        self::assertStringContainsString(
+            "if (\$listOrdering !== '') {",
+            $source,
+            'Pagination links must not serialise list[ordering] while no sort is active: '
+            . 'http_build_query() keeps empty strings, and an empty value reads downstream '
+            . 'as a deliberate ordering.'
+        );
+        self::assertStringNotContainsString(
+            "'ordering' => \$lists['order'] ?? null,",
+            $source,
+            'Emitting list[ordering] unconditionally is the regression itself.'
+        );
+    }
+
+    public function testUnknownSortColumnDegradesInsteadOfFailingThePage(): void
+    {
+        $source = $this->read(self::MODEL);
+
+        $message = 'A sort= naming a column the view does not expose must degrade to the view\'s own '
+            . 'order, like every other embedded parameter. The plugin cannot validate the column '
+            . 'name (it does not know the form labels), so a typo in an article reached this and '
+            . 'returned HTTP 500.';
+
+        $guard = strpos($source, "\$requestedOrdering === '' && \$requestedFullordering === ''");
+        self::assertNotFalse($guard, $message);
+
+        $try = strpos($source, 'try {', $guard);
+        $filter = strpos($source, 'EmbeddedListFieldFilterService::filter(', $guard);
+        $catch = strpos($source, 'catch (\InvalidArgumentException)', $guard);
+
+        self::assertNotFalse($try, $message);
+        self::assertNotFalse($filter, $message);
+        self::assertNotFalse($catch, $message);
+        self::assertLessThan($filter, $try, $message);
+        self::assertLessThan($catch, $filter, $message);
+    }
+
+    public function testDirectionIsReadWithoutStrippingTheSeparator(): void
+    {
+        $source = $this->read(self::MODEL);
+
+        self::assertStringContainsString(
+            "getString('cblist_dir', 'asc')",
+            $source,
+            'cblist_dir carries one direction per sorted column, separated by "|".'
+        );
+        self::assertStringNotContainsString(
+            "getCmd('cblist_dir'",
+            $source,
+            'getCmd() strips "|", collapsing a multi-column "asc|desc" into "ascdesc".'
+        );
+    }
+
+    private function read(string $relativePath): string
+    {
+        $contents = \file_get_contents(\dirname(__DIR__, 4) . '/' . $relativePath);
+        self::assertIsString($contents, 'Unable to read ' . $relativePath);
+
+        return $contents;
+    }
+}

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.7-RC108</version>
+    <version>6.1.7-RC109</version>
     <php_minimum>8.3</php_minimum>
     <changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>

--- a/com_contentbuilderng_changelog.xml
+++ b/com_contentbuilderng_changelog.xml
@@ -3,7 +3,7 @@
 	<changelog>
 		<element>com_contentbuilderng</element>
 		<type>component</type>
-		<version>6.1.7-RC108</version>
+		<version>6.1.7-RC109</version>
 		<addition>
 			<item>Added native DATE, DATETIME, INTEGER, DECIMAL and BOOLEAN controls and validation to direct Storage forms.</item>
 			<item>Added inline Storage field title, SQL type, size and required-state editing, backed by the 6.1.7.104 schema migration.</item>

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,11 +6,11 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.7-RC108</version>
+		<version>6.1.7-RC109</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC108/com_contentbuilderng-6.1.7-RC108.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.7-RC109/com_contentbuilderng-6.1.7-RC109.zip</downloadurl>
 		<sha256>71a90922663edeea450edf4df1221dab154eb1ec3df6bebc351a62a2792757f0</sha256>
 		</downloads>
 		<tags>

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "com_contentbuilderng",
-    "version": "6.1.7-RC108",
+    "version": "6.1.7-RC109",
     "description": "Assets pour le composant ContentBuilderng",
     "assets": [
         {

--- a/plugins/content/contentbuilderng_cblist/contentbuilderng_cblist.xml
+++ b/plugins/content/contentbuilderng_cblist/contentbuilderng_cblist.xml
@@ -7,7 +7,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.7-RC108</version>
+    <version>6.1.7-RC109</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_CBLIST_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngList</namespace>
     <files>

--- a/plugins/content/contentbuilderng_cblist/media/joomla.asset.json
+++ b/plugins/content/contentbuilderng_cblist/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "plg_content_contentbuilderng_cblist",
-    "version": "6.1.7-RC108",
+    "version": "6.1.7-RC109",
     "description": "ContentBuilder NG embedded list assets",
     "license": "GPL-2.0-or-later",
     "assets": [

--- a/plugins/content/contentbuilderng_cbstats/contentbuilderng_cbstats.xml
+++ b/plugins/content/contentbuilderng_cbstats/contentbuilderng_cbstats.xml
@@ -7,7 +7,7 @@
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.7-RC108</version>
+    <version>6.1.7-RC109</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_CBSTATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_cbstats/media/joomla.asset.json
+++ b/plugins/content/contentbuilderng_cbstats/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "plg_content_contentbuilderng_cbstats",
-    "version": "6.1.7-RC108",
+    "version": "6.1.7-RC109",
     "description": "ContentBuilder NG Stats frontend assets",
     "license": "GPL-2.0-or-later",
     "assets": [

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_DOWNLOAD_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngDownload</namespace>

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_IMAGE_SCALE_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngImageScale</namespace>

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_PERMISSION_OBSERVER_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngPermissionObserver</namespace>

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_RATING_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngRating</namespace>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_VERIFY_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngVerify</namespace>

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC108</version>
+  <version>6.1.7-RC109</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC108</version>
+  <version>6.1.7-RC109</version>
   <description><![CDATA[A dark mode theme based on Thoth]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC108</version>
+  <version>6.1.7-RC109</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.7-RC108</version>
+  <version>6.1.7-RC109</version>
   <description><![CDATA[The native ContentBuilder NG Thoth theme]]></description>
   <namespace path="src">CB\Plugin\ContentbuilderngThemes\Thoth</namespace>
   <files>

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.7-RC108</version>
+	<version>6.1.7-RC109</version>
 
 	<description>PLG_SYSTEM_CONTENTBUILDERNG_SYSTEM_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\System\ContentbuilderngSystem</namespace>

--- a/site/layouts/contentbuilderng/list_pagination.php
+++ b/site/layouts/contentbuilderng/list_pagination.php
@@ -46,10 +46,18 @@ $params['id'] = $input->getInt('id', 0);
 $params['Itemid'] = $input->getInt('Itemid', 0);
 $params['list'] = [
     'limit' => $pagLimit,
-    'ordering' => $lists['order'] ?? null,
-    'direction' => $lists['order_Dir'] ?? null,
     'start' => 0,
 ];
+
+// Only carry an ordering the visitor actually chose. http_build_query()
+// keeps empty strings, and an empty list[ordering]= reads downstream as a
+// deliberate ordering, which would override the {CBList sort="..."} order.
+$listOrdering = trim((string) ($lists['order'] ?? ''));
+$listDirection = trim((string) ($lists['order_Dir'] ?? ''));
+if ($listOrdering !== '') {
+    $params['list']['ordering'] = $listOrdering;
+    $params['list']['direction'] = $listDirection;
+}
 $embeddedSort = trim((string) $input->getString('cblist_sort', ''));
 $embeddedDir = trim((string) $input->getString('cblist_dir', ''));
 if (EmbeddedListFieldFilterService::isEmbeddedRequest($input->getCmd('cblist_embed', '')) && $embeddedSort !== '') {

--- a/site/src/Model/ListModel.php
+++ b/site/src/Model/ListModel.php
@@ -1070,22 +1070,41 @@ class ListModel extends BaseListModel
                     // here discarded the {CBList sort="..."} order on every
                     // page change, so only a non-empty value counts as the
                     // visitor having chosen a column to sort on.
-                    $requestedOrdering = trim((string) ($list['ordering'] ?? ''));
-                    $requestedFullordering = trim((string) ($list['fullordering'] ?? ''));
+                    $requestedOrdering = is_array($list['ordering'] ?? null)
+                        ? ''
+                        : trim((string) ($list['ordering'] ?? ''));
+                    $requestedFullordering = is_array($list['fullordering'] ?? null)
+                        ? ''
+                        : trim((string) ($list['fullordering'] ?? ''));
                     if ($isEmbeddedList && $embeddedSort !== '' && $requestedOrdering === '' && $requestedFullordering === '') {
-                        $sortColumns = EmbeddedListFieldFilterService::filter(array_keys($data->labels), $data->labels, [], $embeddedSort);
-                        $sortDirections = explode('|', $embeddedDirection);
-                        $sortOrdering = [];
-                        $sortDirectionValues = [];
-                        foreach ($sortColumns as $index => $sortColumn) {
-                            $sortDirection = strtolower(trim((string) ($sortDirections[$index] ?? '')));
-                            $sortOrdering[] = 'col' . $sortColumn;
-                            // A sort= listing more columns than dir= gives
-                            // directions for leaves the extra ones ascending.
-                            $sortDirectionValues[] = $sortDirection === 'desc' ? 'desc' : 'asc';
+                        try {
+                            $sortColumns = EmbeddedListFieldFilterService::filter(
+                                array_keys($data->labels),
+                                $data->labels,
+                                [],
+                                $embeddedSort
+                            );
+                            $sortDirections = explode('|', $embeddedDirection);
+                            $sortOrdering = [];
+                            $sortDirectionValues = [];
+                            foreach ($sortColumns as $index => $sortColumn) {
+                                $sortDirection = strtolower(trim((string) ($sortDirections[$index] ?? '')));
+                                $sortOrdering[] = 'col' . $sortColumn;
+                                // A sort= listing more columns than dir= gives
+                                // directions for leaves the extra ones ascending.
+                                $sortDirectionValues[] = $sortDirection === 'desc' ? 'desc' : 'asc';
+                            }
+                            $ordering = implode('|', $sortOrdering);
+                            $direction = implode('|', $sortDirectionValues);
+                        } catch (\InvalidArgumentException) {
+                            // sort= names a column this view does not expose —
+                            // a typo in the article's tag reaches here just as
+                            // easily as a hand-crafted URL, and the plugin
+                            // cannot catch it because it does not know the
+                            // form's labels. Degrade to the view's own order
+                            // like every other embedded parameter does, rather
+                            // than failing the whole page.
                         }
-                        $ordering = implode('|', $sortOrdering);
-                        $direction = implode('|', $sortDirectionValues);
                     }
 
                     $isAdminPreview = $app->getInput()->getBool('cb_preview_ok', false);

--- a/site/src/Model/ListModel.php
+++ b/site/src/Model/ListModel.php
@@ -1053,7 +1053,10 @@ class ListModel extends BaseListModel
                     $isEmbeddedList = EmbeddedListFieldFilterService::isEmbeddedRequest($app->getInput()->getCmd('cblist_embed', ''));
                     if ($isEmbeddedList) {
                         $embeddedSort = trim((string) $app->getInput()->getString('cblist_sort', ''));
-                        $embeddedDirection = strtolower(trim((string) $app->getInput()->getCmd('cblist_dir', 'asc')));
+                        // getCmd() strips '|', which would collapse the
+                        // per-column directions of a multi-column sort into a
+                        // single meaningless token ("asc|desc" -> "ascdesc").
+                        $embeddedDirection = strtolower(trim((string) $app->getInput()->getString('cblist_dir', 'asc')));
                     }
 
                     // Guard against ordering by a column that is not part of the SELECT.
@@ -1061,14 +1064,25 @@ class ListModel extends BaseListModel
                     if ($ordering !== '' && !isset($order_types[$ordering]) && !in_array($ordering, $knownOrderKeys, true)) {
                         $ordering = '';
                     }
-                    if ($isEmbeddedList && $embeddedSort !== '' && !isset($list['ordering']) && !isset($list['fullordering'])) {
+                    // Presence is not intent: the pagination links serialise
+                    // list[ordering] even when no column sort is active, and
+                    // isset() is true for that empty string. Testing isset()
+                    // here discarded the {CBList sort="..."} order on every
+                    // page change, so only a non-empty value counts as the
+                    // visitor having chosen a column to sort on.
+                    $requestedOrdering = trim((string) ($list['ordering'] ?? ''));
+                    $requestedFullordering = trim((string) ($list['fullordering'] ?? ''));
+                    if ($isEmbeddedList && $embeddedSort !== '' && $requestedOrdering === '' && $requestedFullordering === '') {
                         $sortColumns = EmbeddedListFieldFilterService::filter(array_keys($data->labels), $data->labels, [], $embeddedSort);
                         $sortDirections = explode('|', $embeddedDirection);
                         $sortOrdering = [];
                         $sortDirectionValues = [];
                         foreach ($sortColumns as $index => $sortColumn) {
+                            $sortDirection = strtolower(trim((string) ($sortDirections[$index] ?? '')));
                             $sortOrdering[] = 'col' . $sortColumn;
-                            $sortDirectionValues[] = $sortDirections[$index];
+                            // A sort= listing more columns than dir= gives
+                            // directions for leaves the extra ones ascending.
+                            $sortDirectionValues[] = $sortDirection === 'desc' ? 'desc' : 'asc';
                         }
                         $ordering = implode('|', $sortOrdering);
                         $direction = implode('|', $sortDirectionValues);


### PR DESCRIPTION
## Résumé

Paginer une liste CBList intégrée réinitialisait le tri : l'ordre demandé par `{CBList sort="..." dir="..."}` était remplacé par celui de la vue, ce qui se lit comme une inversion quand ce dernier va dans l'autre sens.

La branche embarque également la préparation de la version 6.1.7-RC109.

## Cause

Trois défauts s'enchaînaient, et le premier expliquait pourquoi la correction précédente (`dc5b0149`, « Preserve CBList sorting across pagination ») restait sans effet.

**`isset('')` vaut `true`.** Le modèle n'appliquait le tri du tag que si la requête ne portait aucun `list[ordering]`, condition testée avec `isset()`. Or le layout de pagination sérialisait toujours cette clé, même vide, et `http_build_query()` conserve les chaînes vides : chaque lien de page portait donc `list[ordering]=`, ce qui suffisait à faire croire au modèle que le visiteur avait choisi un tri. Le `cblist_sort` que ce même lien venait de préserver était écrasé par un autre paramètre du même lien.

**Pourquoi vide.** Le tri embarqué est calculé dans des variables locales et n'est jamais réinjecté dans l'état de session, que la vue lit pourtant pour alimenter `$lists['order']`. Une fois le tri du tag écarté, le modèle retombait sur cet état puis sur `initial_order_dir`, d'où le changement de sens observé.

**Un troisième défaut, latent.** `cblist_dir` était lu avec `getCmd()`, dont le filtre supprime le caractère `|` : un `dir="asc|desc"` sur un tri multi-colonnes devenait `ascdesc`. Invisible sur une seule colonne, cassant dès la deuxième.

## Correction

La présence est désormais distinguée de l'intention : seule une valeur non vide compte comme un tri choisi par le visiteur, et le layout omet complètement la clé tant qu'aucun tri n'est actif. `cblist_dir` passe par `getString()` et est validé colonne par colonne, les colonnes en surplus tombant en `asc` au lieu de déclencher un index indéfini.

## Vérifications

Suite complète au vert (748 tests), PHPStan sans erreur, PSR-12 sans erreur.

Comportement validé sur une instance réelle, sur `{CBList id=15 fields="Nom|Prenom|Email" sort="Nom" dir="asc" actions="search"}` (36 enregistrements, 2 pages) :

- pages 1 et 2 croissantes, jonction sans rupture, séquence triée de bout en bout ;
- retour en page 1 identique à l'aller, donc aucun résidu d'état de session ;
- les liens de pagination ne portent plus de `list[ordering]` ;
- contre-épreuve : un `list[ordering]` explicite prime toujours sur le tri du tag, le clic sur un en-tête de colonne reste donc fonctionnel.

Les comparaisons d'ordre ont été faites en ignorant les accents, pour correspondre à la collation `utf8mb4_0900_ai_ci` de la base.

## Points à traiter avant publication de la release

**L'empreinte du paquet est celle de RC108.** `com_contentbuilderng_update.xml` annonce désormais l'archive RC109 mais conserve le `sha256` de RC108 (`71a9092…`). C'est exactement ce qui a fait échouer la vérification d'intégrité lors de la mise à jour précédente. Le commit « Update package checksum » devra suivre la publication de l'archive, avant que `main` ne serve le fichier de mise à jour.

**Le changelog ne mentionne aucun des correctifs récents.** Les entrées de RC109 sont identiques à celles de RC108 au numéro de version près. Ni la correction de tri de cette PR, ni l'erreur fatale de pagination corrigée en RC108 n'y figurent — ce sont pourtant les seuls apports concrets de ces deux versions pour un utilisateur. Deux entrées `<fix>` seraient justifiées :

> Fixed a fatal error on front-end list views caused by a missing import in the pagination layout.

> Fixed embedded CBList views losing their `sort=` order when paging through results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
