### PR TITLE
Corriger la migration field_size, les messages non traduits, le scroll de l'Audit — préparer 6.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 6.1.9 — 2026-08-02
+
+### Fixed
+
+- Fixed upgrading from a version that predates the `field_size` column aborting with "Unknown column 'field_size'" during the 6.1.7.104 schema migration.
+- Fixed `COM_CONTENTBUILDERNG_PERMISSIONS_NEW_NOT_ALLOWED` and the equivalent view-permission message rendering as raw untranslated keys on the front end, when raised by the system and permission-observer plugins outside the component's own dispatch.
+- Fixed the admin Audit panel's repair result message not scrolling into view when triggered from deep in a long edit form.
+
 ## 6.1.8 — 2026-08-02
 
 ### Added

--- a/admin/sql/updates/mysql/6.1.7.104.sql
+++ b/admin/sql/updates/mysql/6.1.7.104.sql
@@ -1,5 +1,14 @@
+-- No `AFTER field_size` here on purpose: field_size was never given its own
+-- versioned migration (only install.sql, for fresh installs, and a runtime
+-- self-heal in script.php's postflight, which runs after this file). An
+-- upgrade from a version that predates field_size would hit "Unknown
+-- column 'field_size'" and abort before postflight ever gets a chance to
+-- add it. Appending `required` at the end of the table has no functional
+-- effect — every query in this codebase addresses columns by name — and
+-- postflight's ensureStorageFieldSizeColumn() still adds field_size right
+-- after this file runs, for installs that don't already have it.
 ALTER TABLE `#__contentbuilderng_storage_fields`
-    ADD COLUMN `required` TINYINT(1) NOT NULL DEFAULT 0 AFTER `field_size`;
+    ADD COLUMN `required` TINYINT(1) NOT NULL DEFAULT 0;
 
 UPDATE `#__contentbuilderng_storage_fields` AS `fields`
 INNER JOIN `#__contentbuilderng_storages` AS `storages`

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.8.1</version>
+    <version>6.1.9</version>
     <php_minimum>8.3</php_minimum>
     <changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.8</version>
+    <version>6.1.8.1</version>
     <php_minimum>8.3</php_minimum>
     <changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>

--- a/com_contentbuilderng_changelog.xml
+++ b/com_contentbuilderng_changelog.xml
@@ -3,12 +3,14 @@
 	<changelog>
 		<element>com_contentbuilderng</element>
 		<type>component</type>
-		<version>6.1.8.1</version>
+		<version>6.1.9</version>
 		<addition>
 			<item>Added native DATE, DATETIME, INTEGER, DECIMAL and BOOLEAN controls and validation to direct Storage forms.</item>
 			<item>Added inline Storage field title, SQL type, size and required-state editing, backed by the 6.1.7.104 schema migration.</item>
 			<item>Added field and action allow-lists to embedded CBList views.</item>
+			<item>Added multi-column initial sorting to embedded CBList views via sort=/dir=.</item>
 			<item>Added a theme switcher to the admin preview banner, alongside the existing layout and colour-mode controls.</item>
+			<item>Added a CBList actions section to the frontend debug panel, listing which terms apply on each screen and whether each is currently allowed.</item>
 		</addition>
 		<change>
 			<item>Enabled the repository-wide PSR-12 quality gate and modernized CBStats with strict PHP types.</item>
@@ -18,6 +20,11 @@
 			<item>Escaped free-text list and template output to prevent stored cross-site scripting.</item>
 			<item>Fixed Storage field creation, required-state display, row saving, sorting, system-field publication and schema-audit regressions.</item>
 			<item>Preserved CBList field and action context across navigation, saves and record actions, and hardened action permission checks.</item>
+			<item>Fixed a fatal error on front-end list views caused by a missing import in the pagination layout.</item>
+			<item>Fixed embedded CBList views losing or inverting their sort= order when paging through results.</item>
+			<item>Fixed upgrading from a version that predates the field_size column aborting during the 6.1.7.104 schema migration.</item>
+			<item>Fixed some permission-denied messages rendering as untranslated raw keys on the front end.</item>
+			<item>Fixed the admin Audit panel's repair result message not scrolling into view.</item>
 		</fix>
 	</changelog>
 </changelogs>

--- a/com_contentbuilderng_changelog.xml
+++ b/com_contentbuilderng_changelog.xml
@@ -3,7 +3,7 @@
 	<changelog>
 		<element>com_contentbuilderng</element>
 		<type>component</type>
-		<version>6.1.8</version>
+		<version>6.1.8.1</version>
 		<addition>
 			<item>Added native DATE, DATETIME, INTEGER, DECIMAL and BOOLEAN controls and validation to direct Storage forms.</item>
 			<item>Added inline Storage field title, SQL type, size and required-state editing, backed by the 6.1.7.104 schema migration.</item>

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,11 +6,11 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.8.1</version>
+		<version>6.1.9</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.8.1/com_contentbuilderng-6.1.8.1.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.9/com_contentbuilderng-6.1.9.zip</downloadurl>
 		<sha256>12a7c7f3ba03156437564afa6c5d4a46758adacf6369b305811ddc582fb13c55</sha256>
 		</downloads>
 		<tags>

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,11 +6,11 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.8</version>
+		<version>6.1.8.1</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.8/com_contentbuilderng-6.1.8.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.8.1/com_contentbuilderng-6.1.8.1.zip</downloadurl>
 		<sha256>12a7c7f3ba03156437564afa6c5d4a46758adacf6369b305811ddc582fb13c55</sha256>
 		</downloads>
 		<tags>

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "com_contentbuilderng",
-    "version": "6.1.8",
+    "version": "6.1.8.1",
     "description": "Assets pour le composant ContentBuilderng",
     "assets": [
         {

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "com_contentbuilderng",
-    "version": "6.1.8.1",
+    "version": "6.1.9",
     "description": "Assets pour le composant ContentBuilderng",
     "assets": [
         {

--- a/media/js/form-audit.js
+++ b/media/js/form-audit.js
@@ -9,11 +9,25 @@
         return fallback;
     }
 
+    function scrollMessagesIntoView() {
+        // The Audit tab sits deep in a long tabbed edit form; Joomla's own
+        // renderMessages() only injects into #system-message-container, it
+        // never scrolls to it, so a repair result following an AJAX click
+        // down the page rendered off-screen above the current scroll
+        // position and went unnoticed.
+        var messageContainer = document.getElementById('system-message-container');
+
+        if (messageContainer && typeof messageContainer.scrollIntoView === 'function') {
+            messageContainer.scrollIntoView({behavior: 'smooth', block: 'start'});
+        }
+    }
+
     function renderMessage(type, message) {
         if (window.Joomla && typeof window.Joomla.renderMessages === 'function') {
             var messages = {};
             messages[type] = [message];
             window.Joomla.renderMessages(messages);
+            scrollMessagesIntoView();
             return;
         }
 

--- a/plugins/content/contentbuilderng_cblist/contentbuilderng_cblist.xml
+++ b/plugins/content/contentbuilderng_cblist/contentbuilderng_cblist.xml
@@ -7,7 +7,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.8</version>
+    <version>6.1.8.1</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_CBLIST_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngList</namespace>
     <files>

--- a/plugins/content/contentbuilderng_cblist/contentbuilderng_cblist.xml
+++ b/plugins/content/contentbuilderng_cblist/contentbuilderng_cblist.xml
@@ -7,7 +7,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.8.1</version>
+    <version>6.1.9</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_CBLIST_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngList</namespace>
     <files>

--- a/plugins/content/contentbuilderng_cblist/media/joomla.asset.json
+++ b/plugins/content/contentbuilderng_cblist/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "plg_content_contentbuilderng_cblist",
-    "version": "6.1.8.1",
+    "version": "6.1.9",
     "description": "ContentBuilder NG embedded list assets",
     "license": "GPL-2.0-or-later",
     "assets": [

--- a/plugins/content/contentbuilderng_cblist/media/joomla.asset.json
+++ b/plugins/content/contentbuilderng_cblist/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "plg_content_contentbuilderng_cblist",
-    "version": "6.1.8",
+    "version": "6.1.8.1",
     "description": "ContentBuilder NG embedded list assets",
     "license": "GPL-2.0-or-later",
     "assets": [

--- a/plugins/content/contentbuilderng_cbstats/contentbuilderng_cbstats.xml
+++ b/plugins/content/contentbuilderng_cbstats/contentbuilderng_cbstats.xml
@@ -7,7 +7,7 @@
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.8</version>
+    <version>6.1.8.1</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_CBSTATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_cbstats/contentbuilderng_cbstats.xml
+++ b/plugins/content/contentbuilderng_cbstats/contentbuilderng_cbstats.xml
@@ -7,7 +7,7 @@
     <copyright>This Joomla! plugin is released under the GNU/GPL license</copyright>
     <authorEmail>noreply@vcmb.fr</authorEmail>
     <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-    <version>6.1.8.1</version>
+    <version>6.1.9</version>
     <description>PLG_CONTENT_CONTENTBUILDERNG_CBSTATS_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngStats</namespace>
             <files>

--- a/plugins/content/contentbuilderng_cbstats/media/joomla.asset.json
+++ b/plugins/content/contentbuilderng_cbstats/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "plg_content_contentbuilderng_cbstats",
-    "version": "6.1.8",
+    "version": "6.1.8.1",
     "description": "ContentBuilder NG Stats frontend assets",
     "license": "GPL-2.0-or-later",
     "assets": [

--- a/plugins/content/contentbuilderng_cbstats/media/joomla.asset.json
+++ b/plugins/content/contentbuilderng_cbstats/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "plg_content_contentbuilderng_cbstats",
-    "version": "6.1.8.1",
+    "version": "6.1.9",
     "description": "ContentBuilder NG Stats frontend assets",
     "license": "GPL-2.0-or-later",
     "assets": [

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_DOWNLOAD_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngDownload</namespace>

--- a/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
+++ b/plugins/content/contentbuilderng_download/contentbuilderng_download.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_DOWNLOAD_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngDownload</namespace>

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_IMAGE_SCALE_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngImageScale</namespace>

--- a/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
+++ b/plugins/content/contentbuilderng_image_scale/contentbuilderng_image_scale.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_IMAGE_SCALE_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngImageScale</namespace>

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_PERMISSION_OBSERVER_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngPermissionObserver</namespace>

--- a/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
+++ b/plugins/content/contentbuilderng_permission_observer/contentbuilderng_permission_observer.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_PERMISSION_OBSERVER_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngPermissionObserver</namespace>

--- a/plugins/content/contentbuilderng_permission_observer/src/Extension/ContentbuilderngPermissionObserver.php
+++ b/plugins/content/contentbuilderng_permission_observer/src/Extension/ContentbuilderngPermissionObserver.php
@@ -74,7 +74,13 @@ final class ContentbuilderngPermissionObserver extends CMSPlugin implements Subs
             }
 
             if ($form && !(Factory::getApplication()->getInput()->get('option', '', 'string') == 'com_contentbuilderng' && Factory::getApplication()->getInput()->get('controller', '', 'string') == 'edit')) {
-                Factory::getApplication()->getLanguage()->load('com_contentbuilderng');
+                // com_contentbuilderng's language files are extension-scoped only
+                // (no copy under the global site/administrator language
+                // directory), so load('com_contentbuilderng') with no explicit
+                // base path looks in the wrong place and silently fails,
+                // rendering the permission message below as its raw key.
+                $componentBasePath = ($frontend ? JPATH_SITE : JPATH_ADMINISTRATOR) . '/components/com_contentbuilderng';
+                Factory::getApplication()->getLanguage()->load('com_contentbuilderng', $componentBasePath);
                 (PermissionService::createFromRuntimeContext())->setPermissions($data['form_id'], $data['record_id'], $frontend ? '_fe' : '');
 
                 if (Factory::getApplication()->getInput()->getCmd('view') == 'article') {

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_RATING_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngRating</namespace>

--- a/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
+++ b/plugins/content/contentbuilderng_rating/contentbuilderng_rating.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_RATING_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngRating</namespace>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_VERIFY_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngVerify</namespace>

--- a/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
+++ b/plugins/content/contentbuilderng_verify/contentbuilderng_verify.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>PLG_CONTENT_CONTENTBUILDERNG_VERIFY_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\Content\ContentbuilderngVerify</namespace>

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/trash/trash.xml
+++ b/plugins/contentbuilderng_listaction/trash/trash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_listaction/untrash/untrash.xml
+++ b/plugins/contentbuilderng_listaction/untrash/untrash.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
+++ b/plugins/contentbuilderng_submit/submit_sample/submit_sample.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8</version>
+  <version>6.1.8.1</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/blank/blank.xml
+++ b/plugins/contentbuilderng_themes/blank/blank.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8.1</version>
+  <version>6.1.9</version>
   <description><![CDATA[A blank theme without any style]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Blank</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8</version>
+  <version>6.1.8.1</version>
   <description><![CDATA[A dark mode theme based on Thoth]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/dark/dark.xml
+++ b/plugins/contentbuilderng_themes/dark/dark.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8.1</version>
+  <version>6.1.9</version>
   <description><![CDATA[A dark mode theme based on Thoth]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Dark</namespace>
 

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8</version>
+  <version>6.1.8.1</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/khepri/khepri.xml
+++ b/plugins/contentbuilderng_themes/khepri/khepri.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8.1</version>
+  <version>6.1.9</version>
   <description><![CDATA[A khepri based theme for ContentBuilder Content-Templates]]></description>
     <namespace path="src">CB\Plugin\ContentbuilderngThemes\Khepri</namespace>
           <files>

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8.1</version>
+  <version>6.1.9</version>
   <description><![CDATA[The native ContentBuilder NG Thoth theme]]></description>
   <namespace path="src">CB\Plugin\ContentbuilderngThemes\Thoth</namespace>
   <files>

--- a/plugins/contentbuilderng_themes/thoth/thoth.xml
+++ b/plugins/contentbuilderng_themes/thoth/thoth.xml
@@ -7,7 +7,7 @@
   <license>GNU/GPL v2 or later</license>
   <authorEmail>noreply@vcmb.fr</authorEmail>
   <authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-  <version>6.1.8</version>
+  <version>6.1.8.1</version>
   <description><![CDATA[The native ContentBuilder NG Thoth theme]]></description>
   <namespace path="src">CB\Plugin\ContentbuilderngThemes\Thoth</namespace>
   <files>

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/passthrough/passthrough.xml
+++ b/plugins/contentbuilderng_verify/passthrough/passthrough.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/contentbuilderng_verify/paypal/paypal.xml
+++ b/plugins/contentbuilderng_verify/paypal/paypal.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>
 	<![CDATA[

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8.1</version>
+	<version>6.1.9</version>
 
 	<description>PLG_SYSTEM_CONTENTBUILDERNG_SYSTEM_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\System\ContentbuilderngSystem</namespace>

--- a/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
+++ b/plugins/system/contentbuilderng_system/contentbuilderng_system.xml
@@ -7,7 +7,7 @@
 	<copyright>This Joomla! component is released under the GNU/GPL license</copyright>
 	<authorEmail>noreply@vcmb.fr</authorEmail>
 	<authorUrl>breezingforms-ng.vcmb.fr</authorUrl>
-	<version>6.1.8</version>
+	<version>6.1.8.1</version>
 
 	<description>PLG_SYSTEM_CONTENTBUILDERNG_SYSTEM_XML_DESCRIPTION</description>
     <namespace path="src">CB\Plugin\System\ContentbuilderngSystem</namespace>

--- a/plugins/system/contentbuilderng_system/src/Extension/ContentbuilderngSystem.php
+++ b/plugins/system/contentbuilderng_system/src/Extension/ContentbuilderngSystem.php
@@ -122,6 +122,24 @@ final class ContentbuilderngSystem extends CMSPlugin implements SubscriberInterf
         return class_exists(FormSourceFactory::class);
     }
 
+    /**
+     * com_contentbuilderng's language files are extension-scoped only (no
+     * copy under the global site/administrator language directory), so
+     * Language::load('com_contentbuilderng') with no explicit base path
+     * looks in the wrong place and silently fails: the plugin's messages
+     * then render as their raw language keys. Normal requests to the
+     * component itself don't hit this, since Joomla's own
+     * ComponentDispatcher already retries with the extension-scoped path —
+     * but this plugin can fire outside that dispatch (e.g. blocking a
+     * com_content submission), where no such retry happens.
+     */
+    private function loadComponentLanguage(): void
+    {
+        $basePath = ($this->app->isClient('site') ? JPATH_SITE : JPATH_ADMINISTRATOR)
+            . '/components/com_contentbuilderng';
+        $this->app->getLanguage()->load('com_contentbuilderng', $basePath);
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
@@ -344,7 +362,7 @@ final class ContentbuilderngSystem extends CMSPlugin implements SubscriberInterf
 
             // if somebody tries to submit an article through the built-in joomla content submit
             if ($pluginParams->def('disable_new_articles', 0) && trim($app->getInput()->getCmd('option', '')) == 'com_content' && (trim($app->getInput()->getCmd('task', '')) == 'new' || trim($app->getInput()->getCmd('task', '')) == 'article.add' || (trim($app->getInput()->getCmd('view', '')) == 'article' && trim($app->getInput()->getCmd('layout', '')) == 'form') || (trim($app->getInput()->getCmd('view', '')) == 'form' && trim($app->getInput()->getCmd('layout', '')) == 'edit') && $a_id <= 0)) {
-                $this->app->getLanguage()->load('com_contentbuilderng');
+                $this->loadComponentLanguage();
                 $this->app->enqueueMessage(Text::_('COM_CONTENTBUILDERNG_PERMISSIONS_NEW_NOT_ALLOWED'), 'error');
                 $this->app->redirect('index.php');
             }
@@ -612,8 +630,7 @@ final class ContentbuilderngSystem extends CMSPlugin implements SubscriberInterf
         $list = $this->db->loadAssocList();
 
         if (isset($list[0])) {
-            $lang = $this->app->getLanguage();
-            $lang->load('com_contentbuilderng', JPATH_ADMINISTRATOR);
+            $this->loadComponentLanguage();
         }
 
         $now = (new Date())->toSql();


### PR DESCRIPTION
## Résumé

Trois correctifs et une mise à jour de version/changelogs pour 6.1.9.

### Migration de schéma : `field_size` manquant lors d'une mise à jour ancienne

`admin/sql/updates/mysql/6.1.7.104.sql` ajoutait la colonne `required` avec `AFTER field_size`, alors que `field_size` elle-même n'a jamais eu de migration versionnée — elle n'existe que via `install.sql` (installations neuves) et un rattrapage au runtime dans le `postflight()` de `script.php`. Or Joomla exécute les fichiers de schéma versionnés *avant* d'appeler `update()`/`postflight()` du script d'installation, donc une mise à jour depuis une version antérieure à `field_size` échouait immédiatement avec `Unknown column 'field_size'`, et l'échec interrompait toute la mise à jour avant que le rattrapage n'ait la moindre chance de s'exécuter.

Correction : suppression de la clause `AFTER field_size`, purement cosmétique (aucune requête de ce code ne dépend de l'ordre physique des colonnes). `required` est désormais ajoutée en fin de table, la migration ne référence donc plus rien qui puisse manquer, et le rattrapage de `postflight()` ajoute toujours `field_size` juste après pour les installations qui ne l'ont pas.

Vérifié en rejouant la séquence réelle sur une table reconstituant une installation antérieure à `field_size` : l'instruction non corrigée reproduit exactement l'erreur signalée, la corrigée réussit, et le rattrapage qui suit pose les deux colonnes avec les bons types.

### Messages de plugin non traduits en Front-End

`Language::load('com_contentbuilderng')` sans chemin de base explicite cherche sous `{basePath}/language/{lang}/`, mais les fichiers de langue de ce composant sont exclusivement à portée de l'extension, sous `components/com_contentbuilderng/language/` — il n'existe aucune copie dans le répertoire de langue global. L'appel échouait silencieusement et les messages du plugin s'affichaient sous leur clé brute.

Les requêtes normales vers le composant lui-même ne sont pas concernées : le `ComponentDispatcher` natif de Joomla retente déjà avec le chemin à portée d'extension quand le chemin global est vide. Les deux plugins concernés (`contentbuilderng_system`, `contentbuilderng_permission_observer`) se déclenchent en dehors de ce dispatch — blocage d'une soumission `com_content`, préchargement de chaînes avant création d'articles — donc aucune tentative de rattrapage n'a lieu.

Corrige `COM_CONTENTBUILDERNG_PERMISSIONS_NEW_NOT_ALLOWED` affiché brut en Front-End, ainsi que le même défaut sur `COM_CONTENTBUILDERNG_PERMISSIONS_VIEW_NOT_ALLOWED` dans le plugin d'observation des permissions, repéré en traçant le même motif.

Vérifié directement via `Language::load()`/`hasKey()` : `false` avant, `true` après, et `Text::_()` résout la chaîne française au lieu de la clé brute.

### Panneau Audit : le résultat d'une réparation restait invisible

`Joomla.renderMessages()` insère le message dans `#system-message-container` mais ne fait jamais défiler la page jusqu'à lui. Sur un écran d'édition long avec l'onglet Audit ouvert, un message de réparation (succès ou échec) pouvait s'afficher hors du champ visible, au-dessus de la position de défilement courante.

`media/js/form-audit.js` fait maintenant défiler `#system-message-container` en douceur après chaque rendu de message. Vérifié en rejouant le vrai code du fichier dans un navigateur : après clic sur un bouton de réparation dont la réponse simulée échoue, `window.scrollY` passe de 3000 à 0.

### Version et changelogs

Un bump automatisé antérieur avait renommé la version en `6.1.8.1` — quatre segments numériques, ce qui viole le format `MAJOR.MINOR.PATCH(-prerelease)?` exigé par `VersionConsistencyTest` et faisait échouer la suite sur l'ensemble de la chaîne manifeste/assets. Renumérotée en `6.1.9` partout où elle apparaissait (composant, chaque manifeste de plugin, les deux `joomla.asset.json`, les XML de mise à jour et de changelog).

`CHANGELOG.md` reçoit une entrée 6.1.9 pour les trois correctifs ci-dessus. `com_contentbuilderng_changelog.xml` — le fichier que Joomla affiche réellement lors de la mise à jour — est remis à jour : il lui manquait ces trois correctifs, plus deux correctifs 6.1.8 déjà livrés (l'erreur fatale de pagination, la régression de tri CBList) et deux ajouts 6.1.8 (le tri multi-colonnes, la section Actions CBList du panneau de debug).

## Vérifications

- 752 tests PHPUnit au vert.
- PHPStan : aucune erreur.
- `scripts/build-package.sh` + `scripts/validate-package.sh` : validation du paquet 6.1.9 réussie.

## Point d'attention pour la relecture

Le `sha256` de `com_contentbuilderng_update.xml` pointe vers une release GitHub `v6.1.9` qui n'existe pas encore : je n'ai pas pu calculer une empreinte réelle. Comme lors des précédentes préparations de version, ce commit devra être suivi d'un « Update package checksum » une fois l'archive effectivement publiée — sans quoi la vérification d'intégrité échouera à la mise à jour, comme cela s'est déjà produit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
