### PR TITLE
Prepare 6.1.10-RC07 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.1.10-RC07 — 2026-08-10
+
+### Fixed
+
+- Fixed the View list-limit control not enabling Joomla's Save actions after selecting a standard, custom, inherited or All value.
+
 ## 6.1.10-RC06 — 2026-08-10
 
 ### Added

--- a/admin/src/Field/ListlimitField.php
+++ b/admin/src/Field/ListlimitField.php
@@ -64,7 +64,8 @@ class ListlimitField extends FormField
             . '<input type="text" class="form-control" id="%s" value="%s" inputmode="numeric" autocomplete="off"%s%s%s>'
             . '<button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="%s"%s></button>'
             . '<ul class="dropdown-menu dropdown-menu-end">%s</ul>'
-            . '<input type="hidden" id="%s-value" name="%s" value="%s" data-cb-list-limit-storage%s>'
+            . '<input type="hidden" id="%s-value" name="%s" value="%s"'
+            . ' data-cb-list-limit-storage data-cb-dirty-track="true"%s>'
             . '</div><div class="form-text" data-cb-list-limit-warning hidden>%s</div>',
             $this->escape($mode),
             $this->escape($inheritValue),

--- a/admin/tests/Unit/View/FormSaveButtonTest.php
+++ b/admin/tests/Unit/View/FormSaveButtonTest.php
@@ -29,4 +29,34 @@ final class FormSaveButtonTest extends TestCase
             $script
         );
     }
+
+    public function testCompositeHiddenFieldsCanOptIntoDirtyTracking(): void
+    {
+        $dirtyTrackingScript = file_get_contents(
+            \dirname(__DIR__, 4) . '/media/js/form-edit-init.js'
+        );
+        $listLimitField = file_get_contents(
+            \dirname(__DIR__, 3) . '/src/Field/ListlimitField.php'
+        );
+        $listLimitScript = file_get_contents(
+            \dirname(__DIR__, 4) . '/media/js/list-limit-field.js'
+        );
+
+        self::assertIsString($dirtyTrackingScript);
+        self::assertIsString($listLimitField);
+        self::assertIsString($listLimitScript);
+        self::assertStringContainsString(
+            "type === 'hidden' && field.dataset.cbDirtyTrack === 'true'",
+            $dirtyTrackingScript
+        );
+        self::assertStringContainsString('data-cb-dirty-track="true"', $listLimitField);
+        self::assertStringContainsString(
+            "storage.dispatchEvent(new Event('input', { bubbles: true }))",
+            $listLimitScript
+        );
+        self::assertStringContainsString(
+            "storage.dispatchEvent(new Event('change', { bubbles: true }))",
+            $listLimitScript
+        );
+    }
 }

--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.10-RC06</version>
+    <version>6.1.10-RC07</version>
     <php_minimum>8.3</php_minimum>
     <changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>

--- a/com_contentbuilderng_changelog.xml
+++ b/com_contentbuilderng_changelog.xml
@@ -3,7 +3,7 @@
 	<changelog>
 		<element>com_contentbuilderng</element>
 		<type>component</type>
-		<version>6.1.10-RC06</version>
+		<version>6.1.10-RC07</version>
 		<addition>
 			<item>Added reusable Joomla-style menu controls with dynamic inheritance labels, per-menu themes and true override resets.</item>
 			<item>Added centralized pagination choices shared by component configuration, views, menus and frontend lists.</item>
@@ -24,6 +24,7 @@
 			<item>Direct Storage synchronization now preserves unpublished elements and refreshes native controls when SQL field types change.</item>
 		</change>
 		<fix>
+			<item>Fixed the View list-limit control not enabling Joomla's Save actions after its value changed.</item>
 			<item>Preserved selected ContentBuilder views during updates and menu override resets.</item>
 			<item>Fixed menu translations, encoded group values and inherited or custom list-limit labels.</item>
 			<item>Fixed the dynamic filter order label rendering as a raw language key in the Joomla Menu Item editor.</item>

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,12 +6,11 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.10-RC06</version>
+		<version>6.1.10-RC07</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.10-RC06/com_contentbuilderng-6.1.10-RC06.zip</downloadurl>
-		<sha256>ad79dcec22f99eb689d6cd9ccd2f2e1569c58da9879c5c0f2710678568d54438</sha256>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.10-RC07/com_contentbuilderng-6.1.10-RC07.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>rc</tag>

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "com_contentbuilderng",
-    "version": "6.1.10-RC06",
+    "version": "6.1.10-RC07",
     "description": "Assets pour le composant ContentBuilderng",
     "assets": [
         {

--- a/media/js/form-edit-init.js
+++ b/media/js/form-edit-init.js
@@ -1930,6 +1930,10 @@
 
         var type = String(field.type || '').toLowerCase();
 
+        if (type === 'hidden' && field.dataset.cbDirtyTrack === 'true') {
+            return true;
+        }
+
         if (
             type === 'hidden' &&
             /^(cb_create_sample_flag|cb_create_editable_sample_flag|cb_email_admin_create_sample_flag|cb_email_create_sample_flag)$/.test(String(field.id || ''))


### PR DESCRIPTION
## What changed

- allow the composite View list-limit control to participate in ContentBuilder's existing dirty-form tracking;
- preserve the existing `input` and `change` event flow and all RC06 pagination behaviour;
- add focused regression coverage;
- prepare the `6.1.10-RC07` component, update-stream, asset and changelog metadata.

## Root cause

The control submitted its value through a hidden input. Although the control emitted bubbling `input` and `change` events, the ContentBuilder form-state serializer excluded hidden inputs, so Joomla's Save actions remained disabled.

## Validation

- manual Docker validation of the local RC07;
- PHPUnit: 815 tests, 3527 assertions;
- PSR-12 blocking gate: passed;
- PHPStan: passed;
- XML parsing and version consistency: passed.
