### PR TITLE
Prepare ContentBuilder NG 6.1.10-RC08

### DIFF
--- a/com_contentbuilderng.xml
+++ b/com_contentbuilderng.xml
@@ -6,7 +6,7 @@
     <authorUrl>https://breezingforms-ng.vcmb.fr</authorUrl>
     <copyright>Copyright © 2024 - 2026 XDA+GIL</copyright>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-    <version>6.1.10-RC07</version>
+    <version>6.1.10-RC08</version>
     <php_minimum>8.3</php_minimum>
     <changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
     <description>COM_CONTENTBUILDERNG_XML_DESCRIPTION</description>

--- a/com_contentbuilderng_changelog.xml
+++ b/com_contentbuilderng_changelog.xml
@@ -3,7 +3,7 @@
 	<changelog>
 		<element>com_contentbuilderng</element>
 		<type>component</type>
-		<version>6.1.10-RC07</version>
+		<version>6.1.10-RC08</version>
 		<addition>
 			<item>Added reusable Joomla-style menu controls with dynamic inheritance labels, per-menu themes and true override resets.</item>
 			<item>Added centralized pagination choices shared by component configuration, views, menus and frontend lists.</item>

--- a/com_contentbuilderng_update.xml
+++ b/com_contentbuilderng_update.xml
@@ -6,12 +6,11 @@
 		<element>com_contentbuilderng</element>
 		<type>component</type>
 		<client>1</client>
-		<version>6.1.10-RC07</version>
+		<version>6.1.10-RC08</version>
 		<infourl title="ContentBuilder NG">https://breezingforms-ng.vcmb.fr/</infourl>
 		<changelogurl>https://raw.githubusercontent.com/vcmb-cyclo/com_contentbuilderng/main/com_contentbuilderng_changelog.xml</changelogurl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.10-RC07/com_contentbuilderng-6.1.10-RC07.zip</downloadurl>
-		<sha256>2fed4ab633b1b6ff8568b6d35366513da6eda1fe8951ca373d8a85fbae9fb10c</sha256>
+			<downloadurl type="full" format="zip">https://github.com/vcmb-cyclo/com_contentbuilderng/releases/download/v6.1.10-RC08/com_contentbuilderng-6.1.10-RC08.zip</downloadurl>
 		</downloads>
 		<tags>
 			<tag>rc</tag>

--- a/media/joomla.asset.json
+++ b/media/joomla.asset.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://developer.joomla.org/schemas/json-schema/web_assets.json",
     "name": "com_contentbuilderng",
-    "version": "6.1.10-RC07",
+  "version": "6.1.10-RC08",
     "description": "Assets pour le composant ContentBuilderng",
     "assets": [
         {


### PR DESCRIPTION
## Summary

- update the component manifest to 6.1.10-RC08
- update the Joomla update feed and RC08 download URL
- align the changelog version

The official release workflow will build the package and publish its SHA-256 checksum back to main.